### PR TITLE
Bundle gtest with islpp interface test

### DIFF
--- a/interface/test/CMakeLists.txt
+++ b/interface/test/CMakeLists.txt
@@ -19,8 +19,37 @@ set(ISLPP_INCLUDE_DIR ${ISL_PREFIX}/include/isl/interface)
 # For OSX with brew
 # set(PROTOBUF_LIB_PATH /usr/local/Cellar/)
 
-link_directories($ENV{C2ISL_DIR}/third-party-install/lib)
-set(GOOGLE_LIBS gtest gtest_main gmock)
+# Download and unpack googletest v1.8.0 (latest stable) at configure time
+configure_file(gtest.cmake googletest/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_BINARY_DIR}/test/googletest/src
+                 ${CMAKE_BINARY_DIR}/test/googletest/build)
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+  include_directories("${gtest_SOURCE_DIR}/include")
+endif()
+
+link_directories(${CMAKE_BINARY_DIR}/test/googletest/src/googletest-build/googlemock/)
+link_directories(${CMAKE_BINARY_DIR}/test/googletest/src/googletest-build/googlemock/gtest/)
+set(GOOGLE_LIBS gtest gtest_main gmock gmock_main ${GFLAGS_LIBRARIES})
 
 find_library(ISL_LIB isl HINTS ${ISL_PREFIX}/lib)
 
@@ -28,4 +57,4 @@ include_directories(${ISL_INCLUDE_DIR} ${ISLPP_INCLUDE_DIR})
 
 add_executable(test_islpp test_islpp.cc)
 
-target_link_libraries(test_islpp ${ISL_LIB} ${GOOGLE_LIBS})
+target_link_libraries(test_islpp ${ISL_LIB} ${GOOGLE_LIBS} pthread)

--- a/interface/test/gtest.cmake
+++ b/interface/test/gtest.cmake
@@ -1,0 +1,24 @@
+        cmake_minimum_required(VERSION 2.8.2)
+
+include(ExternalProject)
+
+# Set default ExternalProject root directory
+SET_DIRECTORY_PROPERTIES(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/test/googletest)
+
+ExternalProject_Add(
+    googletest
+    URL https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+    URL_HASH        SHA1=e7e646a6204638fe8e87e165292b8dd9cd4c36ed
+    INSTALL_COMMAND ""
+)
+
+# Specify include dir
+ExternalProject_Get_Property(googletest source_dir)
+set(GTEST_INCLUDE_DIR ${source_dir}/include)
+
+# Library
+ExternalProject_Get_Property(googletest binary_dir)
+set(GTEST_LIBRARY_PATH ${binary_dir}/${CMAKE_FIND_LIBRARY_PREFIXES}gtest.a)
+add_library(GTEST_LIBRARY SHARED IMPORTED)
+set_property(TARGET ${GTEST_LIBRARY} PROPERTY IMPORTED_LOCATION ${GTEST_LIBRARY_PATH} )
+add_dependencies(GTEST_LIBRARY googletest)


### PR DESCRIPTION
A compatible version of gtest is downloaded and linked with the
interface tests when they are built.