### PR TITLE
multi.h: fix wrong memory management annotation

### DIFF
--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -45,7 +45,7 @@ int isl_multi_##BASE##_find_dim_by_id(					\
 	__isl_keep isl_id *id);						\
 __isl_export                                                            \
 __isl_give isl_id *isl_multi_##BASE##_get_dim_id(			\
-	__isl_take isl_multi_##BASE *multi,				\
+	__isl_keep isl_multi_##BASE *multi,				\
 	enum isl_dim_type type, unsigned pos);				\
 __isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_dim_name(		\


### PR DESCRIPTION
Fixes the memory leak problem when using `mutli_*::get_dim_id` through C++ interface.