### PR TITLE
fix automatic mis-merge

### DIFF
--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -4047,8 +4047,6 @@ static struct isl_sched_node *graph_find_compressed_node(isl_ctx *ctx,
 	node = isl_id_get_user(id);
 	isl_id_free(id);
 
-	node = graph_find_node(ctx, graph, node->space);
-
 	if (!node)
 		return NULL;
 


### PR DESCRIPTION
Two slightly different fixes for the same problem (node points to invalid space
/ lookup in the right graph) were applied locally and upstream, both were
merged in and ended up undoing each other's work.