### PR TITLE
drop ISLPP_ASSERT call

### DIFF
--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -761,8 +761,6 @@ void cpp_generator::print_custom_methods_impl(ostream &os,
 
 		osprintf(os, "isl::%s %s::at(int pos) const {\n", element_cpptype,
 			cname);
-		osprintf(os, "  ISLPP_ASSERT(pos >= 0 && pos < size(),\n");
-		osprintf(os, "               \"position out of range\");\n");
 		osprintf(os, "  return manage(%s_list_get_%s(ptr, pos));\n",
 			element_type, element_name);
 		osprintf(os, "}\n\n");


### PR DESCRIPTION
The condition is already checked by the *_list_get_* function and
the use of ISLPP_ASSERT complicates the switch to the isl bindings
with exceptions (which do not have this macro).