### PR TITLE
drop generation of take() and keep() methods

### DIFF
--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -418,8 +418,6 @@ void cpp_generator::print_ptr_decl(ostream &os, const isl_class &clazz)
 	osprintf(os, "  inline __isl_keep %s *get() const;\n", name);
 	osprintf(os, "  inline __isl_give %s *release();\n", name);
         if (extensions) {
-		osprintf(os, "  inline __isl_keep %s *keep() const;\n", name);
-		osprintf(os, "  inline __isl_give %s *take();\n", name);
 		osprintf(os, "  inline explicit operator bool() const;\n", name);
         }
 	osprintf(os, "  inline bool is_null() const;\n");
@@ -716,12 +714,6 @@ void cpp_generator::print_ptr_impl(ostream &os, const isl_class &clazz)
 	osprintf(os, "  return tmp;\n");
 	osprintf(os, "}\n\n");
 	if (extensions) {
-		osprintf(os, "__isl_keep %s *%s::keep() const {\n", name, cppname);
-		osprintf(os, "  return get();\n");
-		osprintf(os, "}\n\n");
-		osprintf(os, "__isl_give %s *%s::take() {\n", name, cppname);
-		osprintf(os, "  return release();\n");
-		osprintf(os, "}\n\n");
 		osprintf(os, "%s::operator bool() const {\n", cppname);
 		osprintf(os, "  return !is_null();\n");
 		osprintf(os, "}\n\n");

--- a/interface/isl-noexceptions.h.pre
+++ b/interface/isl-noexceptions.h.pre
@@ -114,8 +114,6 @@ public:
   inline __isl_give isl_id *copy() && = delete;
   inline __isl_keep isl_id *get() const;
   inline __isl_give isl_id *release();
-  inline __isl_keep isl_id *keep() const;
-  inline __isl_give isl_id *take();
   inline explicit operator bool() const;
   inline isl::ctx get_ctx() const;
   inline bool is_null() const;
@@ -165,14 +163,6 @@ __isl_give isl_id *id::release() {
   isl_id *tmp = ptr;
   ptr = nullptr;
   return tmp;
-}
-
-__isl_keep isl_id *id::keep() const {
-  return get();
-}
-
-__isl_give isl_id *id::take() {
-  return release();
 }
 
 id::operator bool() const {

--- a/interface/isl.h.pre
+++ b/interface/isl.h.pre
@@ -208,8 +208,6 @@ public:
   inline __isl_give isl_id *copy() && = delete;
   inline __isl_keep isl_id *get() const;
   inline __isl_give isl_id *release();
-  inline __isl_keep isl_id *keep() const;
-  inline __isl_give isl_id *take();
   inline explicit operator bool() const;
   inline isl::ctx get_ctx() const;
   inline bool is_null() const;
@@ -259,14 +257,6 @@ __isl_give isl_id *id::release() {
   isl_id *tmp = ptr;
   ptr = nullptr;
   return tmp;
-}
-
-__isl_keep isl_id *id::keep() const {
-  return get();
-}
-
-__isl_give isl_id *id::take() {
-  return release();
 }
 
 id::operator bool() const {

--- a/interface/test/test_islpp.cc
+++ b/interface/test/test_islpp.cc
@@ -130,7 +130,7 @@ isl::set makeUniverseSet(const isl::ctx& ctx, std::vector<const char*> pNames) {
   auto s = isl::set::universe(isl::space(ctx, pNames.size()));
   int idx = 0;
   for (auto n : pNames) {
-    s = isl::manage(isl_set_set_dim_name(s.take(), isl_dim_param, idx++, n));
+    s = isl::manage(isl_set_set_dim_name(s.release(), isl_dim_param, idx++, n));
   }
   return s;
 }
@@ -150,10 +150,10 @@ isl::point makePoint(
     assert(pos >= 0);
     if (vals[idx] >= 0) {
       pt = isl::manage(
-        isl_point_add_ui(pt.take(), isl_dim_param, pos, vals[idx]));
+        isl_point_add_ui(pt.release(), isl_dim_param, pos, vals[idx]));
     } else {
       pt = isl::manage(
-        isl_point_sub_ui(pt.take(), isl_dim_param, pos, -vals[idx]));
+        isl_point_sub_ui(pt.release(), isl_dim_param, pos, -vals[idx]));
     }
     idx++;
   }


### PR DESCRIPTION
They are not available in mainline isl and
the release() and get() methods can be used instead.