### PR TITLE
export isl_schedule_constraints_intersect_domain

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -9500,6 +9500,10 @@ and manipulated using the following functions.
 		__isl_take isl_schedule_constraints *sc,
 		__isl_take isl_multi_union_pw_aff *prefix);
 	__isl_give isl_schedule_constraints *
+	isl_schedule_constraints_intersect_domain(
+		__isl_take isl_schedule_constraints *sc,
+		__isl_take isl_union_set *domain);
+	__isl_give isl_schedule_constraints *
 	isl_schedule_constraints_apply(
 		__isl_take isl_schedule_constraints *sc,
 		__isl_take isl_union_map *umap);
@@ -9561,6 +9565,9 @@ will therefore not appear in the generated schedule,
 except to balance out band schedules.
 That is, for each band schedule there will be at least one
 scheduled statement without any redundant rows.
+
+The function C<isl_schedule_constraints_intersect_domain>
+restricts the domain to be a subset of the given union set.
 
 The function C<isl_schedule_constraints_apply> takes
 schedule constraints that are defined on some set of domain elements

--- a/include/isl/schedule.h
+++ b/include/isl/schedule.h
@@ -123,6 +123,10 @@ __isl_export
 __isl_give isl_multi_union_pw_aff *isl_schedule_constraints_get_prefix(
 	__isl_keep isl_schedule_constraints *sc);
 
+__isl_export
+__isl_give isl_schedule_constraints *isl_schedule_constraints_intersect_domain(
+	__isl_take isl_schedule_constraints *sc,
+	__isl_take isl_union_set *domain);
 __isl_give isl_schedule_constraints *isl_schedule_constraints_apply(
 	__isl_take isl_schedule_constraints *sc,
 	__isl_take isl_union_map *umap);

--- a/isl_schedule_constraints.h
+++ b/isl_schedule_constraints.h
@@ -23,10 +23,6 @@ __isl_give isl_schedule_constraints *isl_schedule_constraints_add(
 	__isl_take isl_schedule_constraints *sc, enum isl_edge_type type,
 	__isl_take isl_union_map *c);
 
-__isl_give isl_schedule_constraints *isl_schedule_constraints_intersect_domain(
-	__isl_take isl_schedule_constraints *sc,
-	__isl_take isl_union_set *domain);
-
 __isl_give
 isl_basic_set *(*isl_schedule_constraints_get_custom_constraint_callback(
 	__isl_keep isl_schedule_constraints *sc))


### PR DESCRIPTION
Intersecting the domain can be usefully combined with
setting a prefix to obtain a partial schedule.