### PR TITLE
do no export isl_set_empty as a constructor

### DIFF
--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -273,7 +273,7 @@ isl_bool isl_basic_set_is_subset(__isl_keep isl_basic_set *bset1,
 isl_bool isl_basic_set_plain_is_equal(__isl_keep isl_basic_set *bset1,
 	__isl_keep isl_basic_set *bset2);
 
-__isl_constructor
+__isl_export
 __isl_give isl_set *isl_set_empty(__isl_take isl_space *space);
 __isl_export
 __isl_give isl_set *isl_set_universe(__isl_take isl_space *space);


### PR DESCRIPTION
There is no unique way of constructing a set from a space.