### PR TITLE
c++: ensure list.begin() == list.end() for empty lists

### DIFF
--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -1010,7 +1010,9 @@ void cpp_generator::print_custom_methods_impl(ostream &os,
 
 		osprintf(os, "typename isl::%s::iterator\n", cname);
 		osprintf(os, "%s::begin() const {\n", cname);
-		osprintf(os, "  return list_iterator<%s>(this, 0);\n",
+		osprintf(os,
+			"  return list_iterator<%s>"
+			"(this, size() == 0 ? -1 : 0);\n",
 			element_cpptype);
 		osprintf(os, "}\n\n");
 

--- a/interface/isl-noexceptions.h
+++ b/interface/isl-noexceptions.h
@@ -1409,11 +1409,11 @@ protected:
 public:
   inline /* implicit */ multi_union_pw_aff();
   inline /* implicit */ multi_union_pw_aff(const isl::multi_union_pw_aff &obj);
-  inline explicit multi_union_pw_aff(isl::ctx ctx, const std::string &str);
   inline /* implicit */ multi_union_pw_aff(isl::union_pw_aff upa);
   inline /* implicit */ multi_union_pw_aff(isl::multi_pw_aff mpa);
   inline explicit multi_union_pw_aff(isl::union_set domain, isl::multi_val mv);
   inline explicit multi_union_pw_aff(isl::union_set domain, isl::multi_aff ma);
+  inline explicit multi_union_pw_aff(isl::ctx ctx, const std::string &str);
   inline isl::multi_union_pw_aff &operator=(isl::multi_union_pw_aff obj);
   inline ~multi_union_pw_aff();
   inline __isl_give isl_multi_union_pw_aff *copy() const &;
@@ -3716,7 +3716,7 @@ isl::ast_node list<ast_node>::operator[](int pos) const {
 
 typename isl::list<ast_node>::iterator
 list<ast_node>::begin() const {
-  return list_iterator<ast_node>(this, 0);
+  return list_iterator<ast_node>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<ast_node>::iterator
@@ -4141,7 +4141,7 @@ isl::basic_map list<basic_map>::operator[](int pos) const {
 
 typename isl::list<basic_map>::iterator
 list<basic_map>::begin() const {
-  return list_iterator<basic_map>(this, 0);
+  return list_iterator<basic_map>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<basic_map>::iterator
@@ -4574,7 +4574,7 @@ isl::basic_set list<basic_set>::operator[](int pos) const {
 
 typename isl::list<basic_set>::iterator
 list<basic_set>::begin() const {
-  return list_iterator<basic_set>(this, 0);
+  return list_iterator<basic_set>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<basic_set>::iterator
@@ -4868,7 +4868,7 @@ isl::constraint list<constraint>::operator[](int pos) const {
 
 typename isl::list<constraint>::iterator
 list<constraint>::begin() const {
-  return list_iterator<constraint>(this, 0);
+  return list_iterator<constraint>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<constraint>::iterator
@@ -4959,7 +4959,7 @@ isl::id list<id>::operator[](int pos) const {
 
 typename isl::list<id>::iterator
 list<id>::begin() const {
-  return list_iterator<id>(this, 0);
+  return list_iterator<id>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<id>::iterator
@@ -6541,11 +6541,6 @@ multi_union_pw_aff::multi_union_pw_aff(const isl::multi_union_pw_aff &obj)
 multi_union_pw_aff::multi_union_pw_aff(__isl_take isl_multi_union_pw_aff *ptr)
     : ptr(ptr) {}
 
-multi_union_pw_aff::multi_union_pw_aff(isl::ctx ctx, const std::string &str)
-{
-  auto res = isl_multi_union_pw_aff_read_from_str(ctx.release(), str.c_str());
-  ptr = res;
-}
 multi_union_pw_aff::multi_union_pw_aff(isl::union_pw_aff upa)
 {
   auto res = isl_multi_union_pw_aff_from_union_pw_aff(upa.release());
@@ -6564,6 +6559,11 @@ multi_union_pw_aff::multi_union_pw_aff(isl::union_set domain, isl::multi_val mv)
 multi_union_pw_aff::multi_union_pw_aff(isl::union_set domain, isl::multi_aff ma)
 {
   auto res = isl_multi_union_pw_aff_multi_aff_on_domain(domain.release(), ma.release());
+  ptr = res;
+}
+multi_union_pw_aff::multi_union_pw_aff(isl::ctx ctx, const std::string &str)
+{
+  auto res = isl_multi_union_pw_aff_read_from_str(ctx.release(), str.c_str());
   ptr = res;
 }
 
@@ -9991,7 +9991,7 @@ isl::set list<set>::operator[](int pos) const {
 
 typename isl::list<set>::iterator
 list<set>::begin() const {
-  return list_iterator<set>(this, 0);
+  return list_iterator<set>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<set>::iterator
@@ -12369,7 +12369,7 @@ isl::val list<val>::operator[](int pos) const {
 
 typename isl::list<val>::iterator
 list<val>::begin() const {
-  return list_iterator<val>(this, 0);
+  return list_iterator<val>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<val>::iterator

--- a/interface/isl.h
+++ b/interface/isl.h
@@ -1493,11 +1493,11 @@ protected:
 public:
   inline /* implicit */ multi_union_pw_aff();
   inline /* implicit */ multi_union_pw_aff(const isl::multi_union_pw_aff &obj);
-  inline explicit multi_union_pw_aff(isl::ctx ctx, const std::string &str);
   inline /* implicit */ multi_union_pw_aff(isl::union_pw_aff upa);
   inline /* implicit */ multi_union_pw_aff(isl::multi_pw_aff mpa);
   inline explicit multi_union_pw_aff(isl::union_set domain, isl::multi_val mv);
   inline explicit multi_union_pw_aff(isl::union_set domain, isl::multi_aff ma);
+  inline explicit multi_union_pw_aff(isl::ctx ctx, const std::string &str);
   inline isl::multi_union_pw_aff &operator=(isl::multi_union_pw_aff obj);
   inline ~multi_union_pw_aff();
   inline __isl_give isl_multi_union_pw_aff *copy() const &;
@@ -4334,7 +4334,7 @@ isl::ast_node list<ast_node>::operator[](int pos) const {
 
 typename isl::list<ast_node>::iterator
 list<ast_node>::begin() const {
-  return list_iterator<ast_node>(this, 0);
+  return list_iterator<ast_node>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<ast_node>::iterator
@@ -5038,7 +5038,7 @@ isl::basic_map list<basic_map>::operator[](int pos) const {
 
 typename isl::list<basic_map>::iterator
 list<basic_map>::begin() const {
-  return list_iterator<basic_map>(this, 0);
+  return list_iterator<basic_map>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<basic_map>::iterator
@@ -5751,7 +5751,7 @@ isl::basic_set list<basic_set>::operator[](int pos) const {
 
 typename isl::list<basic_set>::iterator
 list<basic_set>::begin() const {
-  return list_iterator<basic_set>(this, 0);
+  return list_iterator<basic_set>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<basic_set>::iterator
@@ -6197,7 +6197,7 @@ isl::constraint list<constraint>::operator[](int pos) const {
 
 typename isl::list<constraint>::iterator
 list<constraint>::begin() const {
-  return list_iterator<constraint>(this, 0);
+  return list_iterator<constraint>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<constraint>::iterator
@@ -6299,7 +6299,7 @@ isl::id list<id>::operator[](int pos) const {
 
 typename isl::list<id>::iterator
 list<id>::begin() const {
-  return list_iterator<id>(this, 0);
+  return list_iterator<id>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<id>::iterator
@@ -9186,14 +9186,6 @@ multi_union_pw_aff::multi_union_pw_aff(const isl::multi_union_pw_aff &obj)
 multi_union_pw_aff::multi_union_pw_aff(__isl_take isl_multi_union_pw_aff *ptr)
     : ptr(ptr) {}
 
-multi_union_pw_aff::multi_union_pw_aff(isl::ctx ctx, const std::string &str)
-{
-  options_scoped_set_on_error saved_on_error(ctx, ISL_ON_ERROR_CONTINUE);
-  auto res = isl_multi_union_pw_aff_read_from_str(ctx.release(), str.c_str());
-  if (!res)
-    throw exception::create_from_last_error(ctx);
-  ptr = res;
-}
 multi_union_pw_aff::multi_union_pw_aff(isl::union_pw_aff upa)
 {
   if (upa.is_null())
@@ -9238,6 +9230,14 @@ multi_union_pw_aff::multi_union_pw_aff(isl::union_set domain, isl::multi_aff ma)
   auto ctx = domain.get_ctx();
   options_scoped_set_on_error saved_on_error(ctx, ISL_ON_ERROR_CONTINUE);
   auto res = isl_multi_union_pw_aff_multi_aff_on_domain(domain.release(), ma.release());
+  if (!res)
+    throw exception::create_from_last_error(ctx);
+  ptr = res;
+}
+multi_union_pw_aff::multi_union_pw_aff(isl::ctx ctx, const std::string &str)
+{
+  options_scoped_set_on_error saved_on_error(ctx, ISL_ON_ERROR_CONTINUE);
+  auto res = isl_multi_union_pw_aff_read_from_str(ctx.release(), str.c_str());
   if (!res)
     throw exception::create_from_last_error(ctx);
   ptr = res;
@@ -14897,7 +14897,7 @@ isl::set list<set>::operator[](int pos) const {
 
 typename isl::list<set>::iterator
 list<set>::begin() const {
-  return list_iterator<set>(this, 0);
+  return list_iterator<set>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<set>::iterator
@@ -18971,7 +18971,7 @@ isl::val list<val>::operator[](int pos) const {
 
 typename isl::list<val>::iterator
 list<val>::begin() const {
-  return list_iterator<val>(this, 0);
+  return list_iterator<val>(this, size() == 0 ? -1 : 0);
 }
 
 typename isl::list<val>::iterator


### PR DESCRIPTION
End iterator uses -1 for position.  Begin iterator has been using 0 for
position, which could lead to begin() == end() not being a valid check
for list emptiness.  Use -1 as position of the begin iterator if the
list is empty.