### PR TITLE
scheduler: optionally prevent skewing and scaling

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -9648,6 +9648,11 @@ L</"Schedule Trees">.
 		isl_ctx *ctx);
 	isl_stat isl_options_set_schedule_max_constant_term(
 		isl_ctx *ctx, int val);
+	int isl_options_get_schedule_unit_max_var_coefficient_sum(
+		isl_ctx *ctx);
+	isl_stat
+	isl_options_set_schedule_unit_max_var_coefficient_sum(
+		isl_ctx *ctx, int val);
 	int isl_options_get_schedule_max_constant_term(
 		isl_ctx *ctx);
 	isl_stat isl_options_set_schedule_serialize_sccs(
@@ -9700,6 +9705,14 @@ This option can significantly increase the speed of the scheduling calculation
 and may also prevent fusing of unrelated dimensions. A value of -1 means that
 this option does not introduce bounds on the variable or parameter
 coefficients.
+
+=item * schedule_unit_max_var_coefficient_sum
+
+If this option is set, then the sum of the coefficients for the variables
+(in absolute values) is bounded by one for each statement.
+This means that only schedules that are combinations of permutations and
+reversals on the statement indices are allowed.
+This option has no effect on the Feautrier style scheduler.
 
 =item * schedule_max_constant_term
 

--- a/include/isl/schedule.h
+++ b/include/isl/schedule.h
@@ -20,6 +20,10 @@ typedef struct isl_schedule_constraints isl_schedule_constraints;
 isl_stat isl_options_set_schedule_max_coefficient(isl_ctx *ctx, int val);
 int isl_options_get_schedule_max_coefficient(isl_ctx *ctx);
 
+isl_stat isl_options_set_schedule_unit_max_var_coefficient_sum(isl_ctx *ctx,
+	int val);
+int isl_options_get_schedule_unit_max_var_coefficient_sum(isl_ctx *ctx);
+
 isl_stat isl_options_set_schedule_max_constant_term(isl_ctx *ctx, int val);
 int isl_options_get_schedule_max_constant_term(isl_ctx *ctx);
 

--- a/isl_options.c
+++ b/isl_options.c
@@ -139,6 +139,10 @@ ISL_ARG_INT(struct isl_options, schedule_max_coefficient, 0,
 	"schedule-max-coefficient", "limit", -1, "Only consider schedules "
 	"where the coefficients of the variable and parameter dimensions "
         "do not exceed <limit>. A value of -1 allows arbitrary coefficients.")
+ISL_ARG_BOOL(struct isl_options, schedule_unit_max_var_coefficient_sum, 0,
+	"schedule-unit-max-var-coefficient-sum", 0,
+	"bound the sum of the coefficients of the variables by one "
+	"for each statement")
 ISL_ARG_INT(struct isl_options, schedule_max_constant_term, 0,
 	"schedule-max-constant-term", "limit", -1, "Only consider schedules "
 	"where the coefficients of the constant dimension do not exceed "
@@ -251,6 +255,11 @@ ISL_CTX_SET_INT_DEF(isl_options, struct isl_options, isl_options_args,
 	schedule_max_coefficient)
 ISL_CTX_GET_INT_DEF(isl_options, struct isl_options, isl_options_args,
 	schedule_max_coefficient)
+
+ISL_CTX_SET_BOOL_DEF(isl_options, struct isl_options, isl_options_args,
+	schedule_unit_max_var_coefficient_sum)
+ISL_CTX_GET_BOOL_DEF(isl_options, struct isl_options, isl_options_args,
+	schedule_unit_max_var_coefficient_sum)
 
 ISL_CTX_SET_INT_DEF(isl_options, struct isl_options, isl_options_args,
 	schedule_max_constant_term)

--- a/isl_options_private.h
+++ b/isl_options_private.h
@@ -36,6 +36,7 @@ struct isl_options {
 	int			coalesce_bounded_wrapping;
 
 	int			schedule_max_coefficient;
+	int			schedule_unit_max_var_coefficient_sum;
 	int			schedule_max_constant_term;
 	int			schedule_parametric;
 	int			schedule_outer_coincidence;

--- a/test_inputs/schedule/noskew.sc
+++ b/test_inputs/schedule/noskew.sc
@@ -1,0 +1,5 @@
+# Check that no skewing transformation is found
+# if the skewing preventing option is set.
+# OPTIONS: --schedule-unit-max-var-coefficient-sum
+domain: [N] -> { S[i, j] : 0 <= i, j < N }
+coincidence: { S[i, j] -> S[i + 1, j - 1] }

--- a/test_inputs/schedule/noskew.st
+++ b/test_inputs/schedule/noskew.st
@@ -1,0 +1,4 @@
+domain: "[N] -> { S[i, j] : 0 <= i < N and 0 <= j < N }"
+child:
+  schedule: "[N] -> [{ S[i, j] -> [(i)] }, { S[i, j] -> [(j)] }]"
+  permutable: 1

--- a/test_inputs/schedule/skew.sc
+++ b/test_inputs/schedule/skew.sc
@@ -1,0 +1,5 @@
+# Check that a skewing transformation is found
+# if the skewing preventing option is not set.
+# OPTIONS: --no-schedule-unit-max-var-coefficient-sum
+domain: [N] -> { S[i, j] : 0 <= i, j < N }
+coincidence: { S[i, j] -> S[i + 1, j - 1] }

--- a/test_inputs/schedule/skew.st
+++ b/test_inputs/schedule/skew.st
@@ -1,0 +1,5 @@
+domain: "[N] -> { S[i, j] : 0 <= i < N and 0 <= j < N }"
+child:
+  schedule: "[N] -> [{ S[i, j] -> [(i + j)] }, { S[i, j] -> [(i)] }]"
+  permutable: 1
+  coincident: [ 1, 0 ]


### PR DESCRIPTION
Some applications prefer schedules that do not perform
any skewing (or scaling).  Add an option that bounds
the sum of the absolute values of the coefficients to one
for each statement.
Like all other bounds on coefficients, this option
is ignored by the Feautrier scheduler.

It would be possible to introduce an option that bounds
this sum by an arbitrary number instead, but this would
not play very well with the incremental scheduler
as preventing the sum from accumulating beyond the bound
over successive cluster mergings would require introducing
extra variables in the ILP problem that encode
the absolute values of the coefficients of the original variables
(which may be linear combinations of the cluster variables).
In the special case of bound one, there is no such accumulation.
(Note that the size of individual coefficients
may also grow beyond the schedule_max_coefficient bound
in the current code base, but this can be solved
without introducing such variables.)

Signed-off-by: Sven Verdoolaege <sven.verdoolaege@gmail.com>