### PR TITLE
export isl_ast_build_node_from_schedule

### DIFF
--- a/include/isl/ast_build.h
+++ b/include/isl/ast_build.h
@@ -116,7 +116,7 @@ __isl_overload
 __isl_give isl_ast_expr *isl_ast_build_call_from_multi_pw_aff(
 	__isl_keep isl_ast_build *build, __isl_take isl_multi_pw_aff *mpa);
 
-__isl_export
+__isl_overload
 __isl_give isl_ast_node *isl_ast_build_node_from_schedule(
 	__isl_keep isl_ast_build *build, __isl_take isl_schedule *schedule);
 __isl_export

--- a/isl_test_cpp-generic.cc
+++ b/isl_test_cpp-generic.cc
@@ -239,3 +239,17 @@ static isl::schedule_node test_schedule_tree_generic(isl::ctx ctx)
 
 	return root;
 }
+
+/* Test basic AST generation from a schedule tree that is independent
+ * of the availability of exceptions.
+ *
+ * In particular, create a simple schedule tree and
+ * - generate an AST from the schedule tree
+ */
+static void test_ast_build(isl::ctx ctx)
+{
+	auto schedule = construct_schedule_tree(ctx);
+
+	auto build = isl::ast_build(ctx);
+	auto ast = build.node_from(schedule);
+}

--- a/isl_test_cpp-noexceptions.cc
+++ b/isl_test_cpp-noexceptions.cc
@@ -212,6 +212,7 @@ static void test_schedule_tree(isl::ctx ctx)
  *  - Different return types
  *  - Foreach functions
  *  - Schedule trees
+ *  - AST generation
  */
 int main()
 {
@@ -225,6 +226,7 @@ int main()
 	test_return(ctx);
 	test_foreach(ctx);
 	test_schedule_tree(ctx);
+	test_ast_build(ctx);
 
 	isl_ctx_free(ctx);
 }

--- a/isl_test_cpp.cc
+++ b/isl_test_cpp.cc
@@ -219,6 +219,7 @@ static void test_schedule_tree(isl::ctx ctx)
  *  - Foreach functions
  *  - Exceptions
  *  - Schedule trees
+ *  - AST generation
  */
 int main()
 {
@@ -233,6 +234,7 @@ int main()
 	test_foreach(ctx);
 	test_exception(ctx);
 	test_schedule_tree(ctx);
+	test_ast_build(ctx);
 
 	isl_ctx_free(ctx);
 }

--- a/isl_test_python.py
+++ b/isl_test_python.py
@@ -284,6 +284,17 @@ def test_schedule_tree():
 	root.every_descendant(collect_filters)
 	assert(domain.is_equal(filters[0]))
 
+# Test basic AST generation from a schedule tree.
+#
+# In particular, create a simple schedule tree and
+# - generate an AST from the schedule tree
+#
+def test_ast_build():
+	schedule = construct_schedule_tree()
+
+	build = isl.ast_build()
+	ast = build.node_from(schedule)
+
 # Test the isl Python interface
 #
 # This includes:
@@ -292,9 +303,11 @@ def test_schedule_tree():
 #  - Different return types
 #  - Foreach functions
 #  - Schedule trees
+#  - AST generation
 #
 test_constructors()
 test_parameters()
 test_return()
 test_foreach()
 test_schedule_tree()
+test_ast_build()


### PR DESCRIPTION
Unlike isl_ast_build_node_from_schedule_map (but like
all isl_ast_build_expr_from_* functions),
isl_ast_build_node_from_schedule is exported as an "overloaded"
function because the argument type uniquely determines
how it should be treated.  This is different from
isl_ast_build_node_from_schedule_map, first because
this function does not have a "union_map" suffix, but
more importantly, because the type itself does not
clarify that the argument is a schedule.

Signed-off-by: Sven Verdoolaege <sven.verdoolaege@gmail.com>