### PR TITLE
isl_ast_build_node_from_schedule: propagate coincidence information

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -9912,9 +9912,13 @@ Each type of node has its own additional properties.
 		__isl_keep isl_ast_node *node);
 	isl_bool isl_ast_node_for_is_degenerate(
 		__isl_keep isl_ast_node *node);
+	isl_bool isl_ast_node_for_is_coincident(
+		__isl_keep isl_ast_node *node);
 
 An C<isl_ast_for> is considered degenerate if it is known to execute
 exactly once.
+An C<isl_ast_for> is considered coincident if it corresponds
+to a coincident schedule tree band member.
 
 	#include <isl/ast.h>
 	__isl_give isl_ast_expr *isl_ast_node_if_get_cond(

--- a/include/isl/ast.h
+++ b/include/isl/ast.h
@@ -123,6 +123,7 @@ __isl_give isl_ast_node *isl_ast_node_for_get_body(
 	__isl_keep isl_ast_node *node);
 __isl_export
 isl_bool isl_ast_node_for_is_degenerate(__isl_keep isl_ast_node *node);
+isl_bool isl_ast_node_for_is_coincident(__isl_keep isl_ast_node *node);
 
 __isl_export
 __isl_give isl_ast_expr *isl_ast_node_if_get_cond(

--- a/include/isl/ast.h
+++ b/include/isl/ast.h
@@ -123,6 +123,7 @@ __isl_give isl_ast_node *isl_ast_node_for_get_body(
 	__isl_keep isl_ast_node *node);
 __isl_export
 isl_bool isl_ast_node_for_is_degenerate(__isl_keep isl_ast_node *node);
+__isl_export
 isl_bool isl_ast_node_for_is_coincident(__isl_keep isl_ast_node *node);
 
 __isl_export

--- a/isl_ast.c
+++ b/isl_ast.c
@@ -1067,6 +1067,29 @@ __isl_null isl_ast_node *isl_ast_node_free(__isl_take isl_ast_node *node)
 	return NULL;
 }
 
+/* Error message to be printed when node is not of expected type.
+ */
+static const char *isl_ast_node_type_error[] = {
+	[isl_ast_node_block] = "not a block node",
+	[isl_ast_node_if] = "not an if node",
+	[isl_ast_node_for] = "not a for node",
+	[isl_ast_node_mark] = "not a mark node",
+	[isl_ast_node_user] = "not a user node",
+};
+
+/* Check that "node" is of the given type.
+ */
+static isl_stat isl_ast_node_check_type(__isl_keep isl_ast_node *node,
+	enum isl_ast_node_type type)
+{
+	if (!node)
+		return isl_stat_error;
+	if (node->type != type)
+		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
+			isl_ast_node_type_error[type], return isl_stat_error);
+	return isl_stat_ok;
+}
+
 /* Replace the body of the for node "node" by "body".
  */
 __isl_give isl_ast_node *isl_ast_node_for_set_body(
@@ -1075,9 +1098,8 @@ __isl_give isl_ast_node *isl_ast_node_for_set_body(
 	node = isl_ast_node_cow(node);
 	if (!node || !body)
 		goto error;
-	if (node->type != isl_ast_node_for)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a for node", goto error);
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
+		goto error;
 
 	isl_ast_node_free(node->u.f.body);
 	node->u.f.body = body;
@@ -1092,11 +1114,8 @@ error:
 __isl_give isl_ast_node *isl_ast_node_for_get_body(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_for)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a for node", return NULL);
 	return isl_ast_node_copy(node->u.f.body);
 }
 
@@ -1114,33 +1133,24 @@ __isl_give isl_ast_node *isl_ast_node_for_mark_degenerate(
 
 isl_bool isl_ast_node_for_is_degenerate(__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
 		return isl_bool_error;
-	if (node->type != isl_ast_node_for)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a for node", return isl_bool_error);
 	return node->u.f.degenerate;
 }
 
 __isl_give isl_ast_expr *isl_ast_node_for_get_iterator(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_for)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a for node", return NULL);
 	return isl_ast_expr_copy(node->u.f.iterator);
 }
 
 __isl_give isl_ast_expr *isl_ast_node_for_get_init(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_for)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a for node", return NULL);
 	return isl_ast_expr_copy(node->u.f.init);
 }
 
@@ -1154,11 +1164,8 @@ __isl_give isl_ast_expr *isl_ast_node_for_get_init(
 __isl_give isl_ast_expr *isl_ast_node_for_get_cond(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_for)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a for node", return NULL);
 	if (!node->u.f.degenerate)
 		return isl_ast_expr_copy(node->u.f.cond);
 
@@ -1175,11 +1182,8 @@ __isl_give isl_ast_expr *isl_ast_node_for_get_cond(
 __isl_give isl_ast_expr *isl_ast_node_for_get_inc(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_for)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a for node", return NULL);
 	if (!node->u.f.degenerate)
 		return isl_ast_expr_copy(node->u.f.inc);
 	return isl_ast_expr_alloc_int_si(isl_ast_node_get_ctx(node), 1);
@@ -1193,9 +1197,8 @@ __isl_give isl_ast_node *isl_ast_node_if_set_then(
 	node = isl_ast_node_cow(node);
 	if (!node || !child)
 		goto error;
-	if (node->type != isl_ast_node_if)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not an if node", goto error);
+	if (isl_ast_node_check_type(node, isl_ast_node_if) < 0)
+		goto error;
 
 	isl_ast_node_free(node->u.i.then);
 	node->u.i.then = child;
@@ -1210,66 +1213,48 @@ error:
 __isl_give isl_ast_node *isl_ast_node_if_get_then(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_if) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_if)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not an if node", return NULL);
 	return isl_ast_node_copy(node->u.i.then);
 }
 
 isl_bool isl_ast_node_if_has_else(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_if) < 0)
 		return isl_bool_error;
-	if (node->type != isl_ast_node_if)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not an if node", return isl_bool_error);
 	return node->u.i.else_node != NULL;
 }
 
 __isl_give isl_ast_node *isl_ast_node_if_get_else(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_if) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_if)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not an if node", return NULL);
 	return isl_ast_node_copy(node->u.i.else_node);
 }
 
 __isl_give isl_ast_expr *isl_ast_node_if_get_cond(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_if) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_if)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a guard node", return NULL);
 	return isl_ast_expr_copy(node->u.i.guard);
 }
 
 __isl_give isl_ast_node_list *isl_ast_node_block_get_children(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_block) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_block)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a block node", return NULL);
 	return isl_ast_node_list_copy(node->u.b.children);
 }
 
 __isl_give isl_ast_expr *isl_ast_node_user_get_expr(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_user) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_user)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a user node", return NULL);
 
 	return isl_ast_expr_copy(node->u.e.expr);
 }
@@ -1278,11 +1263,8 @@ __isl_give isl_ast_expr *isl_ast_node_user_get_expr(
  */
 __isl_give isl_id *isl_ast_node_mark_get_id(__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_mark) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_mark)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a mark node", return NULL);
 
 	return isl_id_copy(node->u.m.mark);
 }
@@ -1292,11 +1274,8 @@ __isl_give isl_id *isl_ast_node_mark_get_id(__isl_keep isl_ast_node *node)
 __isl_give isl_ast_node *isl_ast_node_mark_get_node(
 	__isl_keep isl_ast_node *node)
 {
-	if (!node)
+	if (isl_ast_node_check_type(node, isl_ast_node_mark) < 0)
 		return NULL;
-	if (node->type != isl_ast_node_mark)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a mark node", return NULL);
 
 	return isl_ast_node_copy(node->u.m.node);
 }
@@ -2396,9 +2375,8 @@ __isl_give isl_printer *isl_ast_node_for_print(__isl_keep isl_ast_node *node,
 {
 	if (!node || !options)
 		goto error;
-	if (node->type != isl_ast_node_for)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not a for node", goto error);
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
+		goto error;
 	p = print_for_c(p, node, options, 0, 0);
 	isl_ast_print_options_free(options);
 	return p;
@@ -2415,9 +2393,8 @@ __isl_give isl_printer *isl_ast_node_if_print(__isl_keep isl_ast_node *node,
 {
 	if (!node || !options)
 		goto error;
-	if (node->type != isl_ast_node_if)
-		isl_die(isl_ast_node_get_ctx(node), isl_error_invalid,
-			"not an if node", goto error);
+	if (isl_ast_node_check_type(node, isl_ast_node_if) < 0)
+		goto error;
 	p = print_if_c(p, node, options, 1, 0);
 	isl_ast_print_options_free(options);
 	return p;

--- a/isl_ast.c
+++ b/isl_ast.c
@@ -1138,6 +1138,27 @@ isl_bool isl_ast_node_for_is_degenerate(__isl_keep isl_ast_node *node)
 	return node->u.f.degenerate;
 }
 
+/* Mark the given for node as being coincident.
+ */
+__isl_give isl_ast_node *isl_ast_node_for_mark_coincident(
+	__isl_take isl_ast_node *node)
+{
+	node = isl_ast_node_cow(node);
+	if (!node)
+		return NULL;
+	node->u.f.coincident = 1;
+	return node;
+}
+
+/* Is "node" marked coincident?
+ */
+isl_bool isl_ast_node_for_is_coincident(__isl_keep isl_ast_node *node)
+{
+	if (isl_ast_node_check_type(node, isl_ast_node_for) < 0)
+		return isl_bool_error;
+	return node->u.f.coincident;
+}
+
 __isl_give isl_ast_expr *isl_ast_node_for_get_iterator(
 	__isl_keep isl_ast_node *node)
 {

--- a/isl_ast.c
+++ b/isl_ast.c
@@ -2167,6 +2167,7 @@ static __isl_give isl_printer *print_if_c(__isl_take isl_printer *p,
 
 /* Print the body "node" of a for or if node.
  * If "else_node" is set, then it is printed as well.
+ * "parent" is the parent of "node" (and "else_node if it is set).
  * If "force_block" is set, then print out the body as a block.
  *
  * We first check if we need to print out a block.
@@ -2186,6 +2187,7 @@ static __isl_give isl_printer *print_if_c(__isl_take isl_printer *p,
  *	}
  */
 static __isl_give isl_printer *print_body_c(__isl_take isl_printer *p,
+	__isl_keep isl_ast_node *parent,
 	__isl_keep isl_ast_node *node, __isl_keep isl_ast_node *else_node,
 	__isl_keep isl_ast_print_options *options, int force_block)
 {
@@ -2214,7 +2216,8 @@ static __isl_give isl_printer *print_body_c(__isl_take isl_printer *p,
 			p = print_if_c(p, else_node, options, 0, 1);
 		} else {
 			p = isl_printer_print_str(p, " else");
-			p = print_body_c(p, else_node, NULL, options, 1);
+			p = print_body_c(p, parent, else_node, NULL,
+					options, 1);
 		}
 	} else
 		p = isl_printer_end_line(p);
@@ -2292,7 +2295,7 @@ static __isl_give isl_printer *print_for_c(__isl_take isl_printer *p,
 		p = isl_printer_print_str(p, " += ");
 		p = isl_printer_print_ast_expr(p, node->u.f.inc);
 		p = isl_printer_print_str(p, ")");
-		p = print_body_c(p, node->u.f.body, NULL, options, 0);
+		p = print_body_c(p, node, node->u.f.body, NULL, options, 0);
 	} else {
 		id = isl_ast_expr_get_id(node->u.f.iterator);
 		name = isl_id_get_name(id);
@@ -2329,7 +2332,7 @@ static __isl_give isl_printer *print_if_c(__isl_take isl_printer *p,
 	p = isl_printer_print_str(p, "if (");
 	p = isl_printer_print_ast_expr(p, node->u.i.guard);
 	p = isl_printer_print_str(p, ")");
-	p = print_body_c(p, node->u.i.then, node->u.i.else_node, options,
+	p = print_body_c(p, node, node->u.i.then, node->u.i.else_node, options,
 			force_block);
 
 	return p;

--- a/isl_ast.c
+++ b/isl_ast.c
@@ -2165,6 +2165,23 @@ static __isl_give isl_printer *print_if_c(__isl_take isl_printer *p,
 	__isl_keep isl_ast_print_options *options, int new_line,
 	int force_block);
 
+/* If "node" is a coincident for node, then print " // coincident" to "p".
+ */
+static __isl_give isl_printer *print_coincident(__isl_take isl_printer *p,
+	__isl_keep isl_ast_node *node)
+{
+	isl_bool coincident;
+
+	if (node->type != isl_ast_node_for)
+		return p;
+	coincident = isl_ast_node_for_is_coincident(node);
+	if (coincident < 0)
+		return isl_printer_free(p);
+	if (coincident)
+		p = isl_printer_print_str(p, " // coincident");
+	return p;
+}
+
 /* Print the body "node" of a for or if node.
  * If "else_node" is set, then it is printed as well.
  * "parent" is the parent of "node" (and "else_node if it is set).
@@ -2174,6 +2191,9 @@ static __isl_give isl_printer *print_if_c(__isl_take isl_printer *p,
  * We always print out a block if there is an else node to make
  * sure that the else node is matched to the correct if node.
  * For consistency, the corresponding else node is also printed as a block.
+ *
+ * If "node" is a coincident for node, then print " // coincident"
+ * at the end of the line.
  *
  * If the else node is itself an if, then we print it as
  *
@@ -2195,6 +2215,7 @@ static __isl_give isl_printer *print_body_c(__isl_take isl_printer *p,
 		return isl_printer_free(p);
 
 	if (!force_block && !else_node && !need_block(node)) {
+		p = print_coincident(p, parent);
 		p = isl_printer_end_line(p);
 		p = isl_printer_indent(p, 2);
 		p = isl_ast_node_print(node, p,
@@ -2204,6 +2225,7 @@ static __isl_give isl_printer *print_body_c(__isl_take isl_printer *p,
 	}
 
 	p = isl_printer_print_str(p, " {");
+	p = print_coincident(p, parent);
 	p = isl_printer_end_line(p);
 	p = isl_printer_indent(p, 2);
 	p = print_ast_node_c(p, node, options, 1, 0);

--- a/isl_ast_build.c
+++ b/isl_ast_build.c
@@ -1056,10 +1056,11 @@ __isl_give isl_schedule_node *isl_ast_build_get_schedule_node(
 	return isl_schedule_node_copy(build->node);
 }
 
-/* Extract the loop AST generation types for the members of build->node
+/* Extract information attached to the members of build->node.
+ * In particular, extract the loop AST generation types
  * and store them in build->loop_type.
  */
-static __isl_give isl_ast_build *extract_loop_types(
+static __isl_give isl_ast_build *extract_member_data(
 	__isl_take isl_ast_build *build)
 {
 	int i, n;
@@ -1100,7 +1101,7 @@ __isl_give isl_ast_build *isl_ast_build_set_schedule_node(
 	isl_schedule_node_free(build->node);
 	build->node = node;
 
-	build = extract_loop_types(build);
+	build = extract_member_data(build);
 
 	return build;
 error:
@@ -2223,7 +2224,7 @@ __isl_give isl_set *isl_ast_build_get_option_domain(
 
 /* How does the user want the current schedule dimension to be generated?
  * These choices have been extracted from the schedule node
- * in extract_loop_types and stored in build->loop_type.
+ * in extract_member_data and stored in build->loop_type.
  * They have been updated to reflect any dimension insertion in
  * node_insert_dim.
  * Return isl_ast_domain_error on error.

--- a/isl_ast_build.c
+++ b/isl_ast_build.c
@@ -1024,10 +1024,10 @@ error:
 /* Does "build" point to a band node?
  * That is, are we currently handling a band node inside a schedule tree?
  */
-int isl_ast_build_has_schedule_node(__isl_keep isl_ast_build *build)
+isl_bool isl_ast_build_has_schedule_node(__isl_keep isl_ast_build *build)
 {
 	if (!build)
-		return -1;
+		return isl_bool_error;
 	return build->node != NULL;
 }
 

--- a/isl_ast_build_expr.c
+++ b/isl_ast_build_expr.c
@@ -1423,7 +1423,7 @@ static int cmp_constraint(__isl_keep isl_constraint *a,
 /* Construct an isl_ast_expr that evaluates the conditions defining "bset".
  * The result is simplified in terms of build->domain.
  *
- * If "bset" is not bounded by any constraint, then we contruct
+ * If "bset" is not bounded by any constraint, then we construct
  * the expression "1", i.e., "true".
  *
  * Otherwise, we sort the constraints, putting constraints that involve

--- a/isl_ast_build_private.h
+++ b/isl_ast_build_private.h
@@ -50,7 +50,7 @@
  *
  * "strides" contains the stride of each loop.  The number of elements
  * is equal to the number of dimensions in "domain".
- * "offsets" constains the offsets of strided loops.  If s is the stride
+ * "offsets" contains the offsets of strided loops.  If s is the stride
  * for a given dimension and f is the corresponding offset, then the
  * dimension takes on values
  *
@@ -133,7 +133,7 @@
  * an AST from a schedule tree.  It may be NULL if we are not generating
  * an AST from a schedule tree or if we are not inside a band node.
  *
- * "loop_type" originally constains loop AST generation types for
+ * "loop_type" originally contains loop AST generation types for
  * the "n" members of "node" and it is updated (along with "n") when
  * a schedule dimension is inserted.
  * It is NULL if "node" is NULL.

--- a/isl_ast_build_private.h
+++ b/isl_ast_build_private.h
@@ -256,7 +256,7 @@ int isl_ast_build_has_value(__isl_keep isl_ast_build *build);
 __isl_give isl_id *isl_ast_build_get_iterator_id(
 	__isl_keep isl_ast_build *build, int pos);
 
-int isl_ast_build_has_schedule_node(__isl_keep isl_ast_build *build);
+isl_bool isl_ast_build_has_schedule_node(__isl_keep isl_ast_build *build);
 __isl_give isl_schedule_node *isl_ast_build_get_schedule_node(
 	__isl_keep isl_ast_build *build);
 __isl_give isl_ast_build *isl_ast_build_set_schedule_node(

--- a/isl_ast_build_private.h
+++ b/isl_ast_build_private.h
@@ -134,9 +134,12 @@
  * an AST from a schedule tree or if we are not inside a band node.
  *
  * "loop_type" originally contains loop AST generation types for
- * the "n" members of "node" and it is updated (along with "n") when
+ * the "n" members of "node", while
+ * "coincident" originally contains the coincidence information
+ * of the same members.
+ * Both fields are updated (along with "n") when
  * a schedule dimension is inserted.
- * It is NULL if "node" is NULL.
+ * They are NULL if "node" is NULL.
  *
  * "isolated" is the piece of the schedule domain isolated by the isolate
  * option on the current band.  This set may be NULL if we have not checked
@@ -196,6 +199,7 @@ struct isl_ast_build {
 	isl_schedule_node *node;
 	int n;
 	enum isl_ast_loop_type *loop_type;
+	isl_bool *coincident;
 	isl_set *isolated;
 };
 
@@ -319,6 +323,7 @@ __isl_give isl_set *isl_ast_build_eliminate_divs(
 
 enum isl_ast_loop_type isl_ast_build_get_loop_type(
 	__isl_keep isl_ast_build *build, int isolated);
+isl_bool isl_ast_build_is_coincident(__isl_keep isl_ast_build *build);
 
 __isl_give isl_map *isl_ast_build_map_to_iterator(
 	__isl_keep isl_ast_build *build, __isl_take isl_set *set);

--- a/isl_ast_codegen.c
+++ b/isl_ast_codegen.c
@@ -2651,7 +2651,7 @@ static int foreach_iteration(__isl_take isl_set *domain,
  * "executed" and "build" are inputs to compute_domains.
  * "schedule_domain" is the domain of "executed".
  *
- * "option" constains the domains at the current depth that should by
+ * "option" contains the domains at the current depth that should by
  * atomic, separated or unrolled.  These domains are as specified by
  * the user, except that inner dimensions have been eliminated and
  * that they have been made pair-wise disjoint.
@@ -3953,7 +3953,7 @@ static __isl_give isl_union_map *construct_shifted_executed(
  * Based on this information, we construct a new inverse schedule in
  * construct_shifted_executed that exposes the stride.
  * Since this involves the introduction of a new schedule dimension,
- * the build needs to be changed accodingly.
+ * the build needs to be changed accordingly.
  * After computing the AST, the newly introduced dimension needs
  * to be removed again from the list of grafts.  We do this by plugging
  * in a mapping that represents the new schedule domain in terms of the

--- a/isl_ast_codegen.c
+++ b/isl_ast_codegen.c
@@ -3880,7 +3880,7 @@ static int first_offset(struct isl_set_map_pair *domain, int *order, int n,
  * with "<<" the lexicographic order, proving that the order is preserved
  * in all cases.
  */
-static __isl_give isl_union_map *contruct_shifted_executed(
+static __isl_give isl_union_map *construct_shifted_executed(
 	struct isl_set_map_pair *domain, int *order, int n,
 	__isl_keep isl_val *stride, __isl_keep isl_multi_val *offset,
 	__isl_take isl_ast_build *build)
@@ -3951,7 +3951,7 @@ static __isl_give isl_union_map *contruct_shifted_executed(
  * domain is equal to zero.  The other offsets are reduced modulo stride.
  *
  * Based on this information, we construct a new inverse schedule in
- * contruct_shifted_executed that exposes the stride.
+ * construct_shifted_executed that exposes the stride.
  * Since this involves the introduction of a new schedule dimension,
  * the build needs to be changed accodingly.
  * After computing the AST, the newly introduced dimension needs
@@ -3985,7 +3985,7 @@ static __isl_give isl_ast_graft_list *generate_shift_component(
 	mv = isl_multi_val_add_val(mv, val);
 	mv = isl_multi_val_mod_val(mv, isl_val_copy(stride));
 
-	executed = contruct_shifted_executed(domain, order, n, stride, mv,
+	executed = construct_shifted_executed(domain, order, n, stride, mv,
 						build);
 	space = isl_ast_build_get_space(build, 1);
 	space = isl_space_map_from_set(space);

--- a/isl_ast_private.h
+++ b/isl_ast_private.h
@@ -48,6 +48,8 @@ __isl_give isl_ast_expr *isl_ast_expr_alloc_binary(enum isl_ast_op_type type,
 /* A node is either a block, an if, a for, a user node or a mark node.
  * "else_node" is NULL if the if node does not have an else branch.
  * "cond" and "inc" are NULL for degenerate for nodes.
+ * "coincident" is set on a for node if it corresponds
+ * to a coincident band member.
  * In case of a mark node, "mark" is the mark and "node" is the marked node.
  */
 struct isl_ast_node {
@@ -67,6 +69,7 @@ struct isl_ast_node {
 		} i;
 		struct {
 			unsigned degenerate : 1;
+			unsigned coincident : 1;
 			isl_ast_expr *iterator;
 			isl_ast_expr *init;
 			isl_ast_expr *cond;
@@ -87,6 +90,8 @@ struct isl_ast_node {
 
 __isl_give isl_ast_node *isl_ast_node_alloc_for(__isl_take isl_id *id);
 __isl_give isl_ast_node *isl_ast_node_for_mark_degenerate(
+	__isl_take isl_ast_node *node);
+__isl_give isl_ast_node *isl_ast_node_for_mark_coincident(
 	__isl_take isl_ast_node *node);
 __isl_give isl_ast_node *isl_ast_node_alloc_if(__isl_take isl_ast_expr *guard);
 __isl_give isl_ast_node *isl_ast_node_alloc_block(

--- a/isl_convex_hull.c
+++ b/isl_convex_hull.c
@@ -1557,7 +1557,7 @@ static void update_constraint(struct isl_ctx *ctx, struct isl_hash_table *table,
 	c->ineq = ineq;
 }
 
-/* Check whether the constraint hash table "table" constains the constraint
+/* Check whether the constraint hash table "table" contains the constraint
  * "con".
  */
 static int has_constraint(struct isl_ctx *ctx, struct isl_hash_table *table,

--- a/test_inputs/codegen/correlation.c
+++ b/test_inputs/codegen/correlation.c
@@ -1,17 +1,17 @@
-for (int c0 = 0; c0 < m; c0 += 32)
-  for (int c1 = (n >= 32 && m >= c0 + 2) || (m == 1 && c0 == 0) ? 0 : 32 * n - 32 * floord(31 * n + 31, 32); c1 <= ((n <= -1 && c0 == 0) || (m == 1 && n >= 0 && c0 == 0) ? max(0, n - 1) : n); c1 += 32)
-    for (int c2 = c0; c2 <= (m >= 2 && c0 + 31 >= m && n >= c1 && c1 + 31 >= n ? 2 * m - 3 : (m >= 2 * c0 + 63 && c1 <= -32 && n >= c1 && c1 + 31 >= n) || (m >= c0 + 32 && 2 * c0 + 62 >= m && n >= c1 && c1 + 31 >= n) || (n >= 0 && c0 >= 32 && m >= 2 * c0 + 63 && c1 == n) || (m >= 63 && n >= 32 && c0 == 0 && c1 == n) ? 2 * c0 + 61 : m - 1); c2 += 32) {
+for (int c0 = 0; c0 < m; c0 += 32) // coincident
+  for (int c1 = (n >= 32 && m >= c0 + 2) || (m == 1 && c0 == 0) ? 0 : 32 * n - 32 * floord(31 * n + 31, 32); c1 <= ((n <= -1 && c0 == 0) || (m == 1 && n >= 0 && c0 == 0) ? max(0, n - 1) : n); c1 += 32) // coincident
+    for (int c2 = c0; c2 <= (m >= 2 && c0 + 31 >= m && n >= c1 && c1 + 31 >= n ? 2 * m - 3 : (m >= 2 * c0 + 63 && c1 <= -32 && n >= c1 && c1 + 31 >= n) || (m >= c0 + 32 && 2 * c0 + 62 >= m && n >= c1 && c1 + 31 >= n) || (n >= 0 && c0 >= 32 && m >= 2 * c0 + 63 && c1 == n) || (m >= 63 && n >= 32 && c0 == 0 && c1 == n) ? 2 * c0 + 61 : m - 1); c2 += 32) { // coincident
       if (n >= c1 + 32 && c1 >= 0 && 2 * c0 >= c2 + 32) {
-        for (int c4 = 0; c4 <= 31; c4 += 1)
-          for (int c5 = max(0, c0 - c2 + 1); c5 <= min(31, m - c2 - 1); c5 += 1)
+        for (int c4 = 0; c4 <= 31; c4 += 1) // coincident
+          for (int c5 = max(0, c0 - c2 + 1); c5 <= min(31, m - c2 - 1); c5 += 1) // coincident
             S_27(c0, c2 + c5, c1 + c4);
       } else if (c0 >= 32 && c1 >= 0 && c2 >= 2 * c0) {
-        for (int c4 = 0; c4 <= min(31, n - c1 - 1); c4 += 1)
-          for (int c5 = 0; c5 <= min(31, m - c2 - 1); c5 += 1)
+        for (int c4 = 0; c4 <= min(31, n - c1 - 1); c4 += 1) // coincident
+          for (int c5 = 0; c5 <= min(31, m - c2 - 1); c5 += 1) // coincident
             S_27(c0, c2 + c5, c1 + c4);
       } else if (c0 == 0 && c1 >= 0) {
-        for (int c4 = 0; c4 <= min(31, n - c1 - 1); c4 += 1)
-          for (int c5 = 0; c5 <= min(31, m - c2 - 1); c5 += 1) {
+        for (int c4 = 0; c4 <= min(31, n - c1 - 1); c4 += 1) // coincident
+          for (int c5 = 0; c5 <= min(31, m - c2 - 1); c5 += 1) { // coincident
             if (c1 == 0 && c4 == 0)
               S_14(c2 + c5);
             S_19(c1 + c4, c2 + c5);
@@ -20,26 +20,26 @@ for (int c0 = 0; c0 < m; c0 += 32)
           }
       }
       if (c1 >= 0) {
-        for (int c3 = 1; c3 <= min(31, (c2 / 2) - c0); c3 += 1)
-          for (int c4 = 0; c4 <= min(31, n - c1 - 1); c4 += 1)
-            for (int c5 = 0; c5 <= min(31, m - c2 - 1); c5 += 1)
+        for (int c3 = 1; c3 <= min(31, (c2 / 2) - c0); c3 += 1) // coincident
+          for (int c4 = 0; c4 <= min(31, n - c1 - 1); c4 += 1) // coincident
+            for (int c5 = 0; c5 <= min(31, m - c2 - 1); c5 += 1) // coincident
               S_27(c0 + c3, c2 + c5, c1 + c4);
         if (n >= c1 + 32) {
-          for (int c3 = max(1, (c2 / 2) - c0 + 1); c3 <= min(min(31, m - c0 - 2), -c0 + c2 + 30); c3 += 1)
-            for (int c4 = 0; c4 <= 31; c4 += 1)
-              for (int c5 = max(0, c0 - c2 + c3 + 1); c5 <= min(31, m - c2 - 1); c5 += 1)
+          for (int c3 = max(1, (c2 / 2) - c0 + 1); c3 <= min(min(31, m - c0 - 2), -c0 + c2 + 30); c3 += 1) // coincident
+            for (int c4 = 0; c4 <= 31; c4 += 1) // coincident
+              for (int c5 = max(0, c0 - c2 + c3 + 1); c5 <= min(31, m - c2 - 1); c5 += 1) // coincident
                 S_27(c0 + c3, c2 + c5, c1 + c4);
         } else if (n <= 0 && c0 == 0 && c1 == 0) {
-          for (int c5 = 0; c5 <= min(31, m - c2 - 1); c5 += 1)
+          for (int c5 = 0; c5 <= min(31, m - c2 - 1); c5 += 1) // coincident
             S_14(c2 + c5);
         }
       }
       if (n >= c1 && c1 + 31 >= n)
-        for (int c3 = max(0, (c2 / 2) - c0 + 1); c3 <= min(31, m - c0 - 1); c3 += 1) {
-          for (int c4 = max(0, -c1); c4 < n - c1; c4 += 1)
-            for (int c5 = max(0, c0 - c2 + c3 + 1); c5 <= min(31, m - c2 - 1); c5 += 1)
+        for (int c3 = max(0, (c2 / 2) - c0 + 1); c3 <= min(31, m - c0 - 1); c3 += 1) { // coincident
+          for (int c4 = max(0, -c1); c4 < n - c1; c4 += 1) // coincident
+            for (int c5 = max(0, c0 - c2 + c3 + 1); c5 <= min(31, m - c2 - 1); c5 += 1) // coincident
               S_27(c0 + c3, c2 + c5, c1 + c4);
-          for (int c5 = max(0, c0 - c2 + c3); c5 <= min(31, 2 * c0 - c2 + 2 * c3 - 1); c5 += 1)
+          for (int c5 = max(0, c0 - c2 + c3); c5 <= min(31, 2 * c0 - c2 + 2 * c3 - 1); c5 += 1) // coincident
             S_29(-c0 + c2 - c3 + c5, c0 + c3);
         }
     }

--- a/test_inputs/codegen/gemm.c
+++ b/test_inputs/codegen/gemm.c
@@ -1,5 +1,5 @@
-for (int c0 = 0; c0 < ni; c0 += 1)
-  for (int c1 = 0; c1 < nj; c1 += 1) {
+for (int c0 = 0; c0 < ni; c0 += 1) // coincident
+  for (int c1 = 0; c1 < nj; c1 += 1) { // coincident
     S_2(c0, c1);
     for (int c2 = 0; c2 < nk; c2 += 1)
       S_4(c0, c1, c2);


### PR DESCRIPTION
In particular, if a generated for node corresponds
to a band member that is marked coincident, then also
mark this for node as coincident.