### PR TITLE
remove exports of most isl_*_find_dim_by_* functions

### DIFF
--- a/include/isl/local_space.h
+++ b/include/isl/local_space.h
@@ -62,7 +62,6 @@ __isl_export
 __isl_give isl_aff *isl_local_space_get_div(__isl_keep isl_local_space *ls,
 	int pos);
 
-__isl_export
 int isl_local_space_find_dim_by_name(__isl_keep isl_local_space *ls,
 	enum isl_dim_type type, const char *name);
 

--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -118,10 +118,8 @@ __isl_give isl_map *isl_map_reset_user(__isl_take isl_map *map);
 
 int isl_basic_map_find_dim_by_name(__isl_keep isl_basic_map *bmap,
 	enum isl_dim_type type, const char *name);
-__isl_export
 int isl_map_find_dim_by_id(__isl_keep isl_map *map, enum isl_dim_type type,
 	__isl_keep isl_id *id);
-__isl_export
 int isl_map_find_dim_by_name(__isl_keep isl_map *map, enum isl_dim_type type,
 	const char *name);
 

--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -21,7 +21,6 @@ __isl_give isl_space *isl_multi_##BASE##_get_space(			\
 __isl_export								\
 __isl_give isl_space *isl_multi_##BASE##_get_domain_space(		\
 	__isl_keep isl_multi_##BASE *multi);				\
-__isl_export								\
 int isl_multi_##BASE##_find_dim_by_name(				\
 	__isl_keep isl_multi_##BASE *multi,				\
 	enum isl_dim_type type, const char *name);			\
@@ -39,7 +38,6 @@ isl_bool isl_multi_##BASE##_plain_is_equal(				\
 	__isl_keep isl_multi_##BASE *multi2);				\
 isl_bool isl_multi_##BASE##_involves_nan(				\
 	__isl_keep isl_multi_##BASE *multi);				\
-__isl_export                                                            \
 int isl_multi_##BASE##_find_dim_by_id(					\
 	__isl_keep isl_multi_##BASE *multi, enum isl_dim_type type,	\
 	__isl_keep isl_id *id);						\

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -105,10 +105,8 @@ __isl_export
 __isl_give isl_id *isl_set_get_tuple_id(__isl_keep isl_set *set);
 __isl_give isl_set *isl_set_reset_user(__isl_take isl_set *set);
 
-__isl_export
 int isl_set_find_dim_by_id(__isl_keep isl_set *set, enum isl_dim_type type,
 	__isl_keep isl_id *id);
-__isl_export
 int isl_set_find_dim_by_name(__isl_keep isl_set *set, enum isl_dim_type type,
 	const char *name);
 

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -86,7 +86,6 @@ __isl_export
 __isl_give isl_id *isl_space_get_dim_id(__isl_keep isl_space *dim,
 	enum isl_dim_type type, unsigned pos);
 
-__isl_export
 int isl_space_find_dim_by_id(__isl_keep isl_space *dim, enum isl_dim_type type,
 	__isl_keep isl_id *id);
 __isl_export


### PR DESCRIPTION
isl_space_find_dim_by_name is left exported for now.
This export will be removed later.