### PR TITLE
add isl_*_list_reverse

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -7842,6 +7842,9 @@ Lists can be created, copied, modified and freed using the following functions.
 	__isl_give isl_set_list *isl_set_list_drop(
 		__isl_take isl_set_list *list,
 		unsigned first, unsigned n);
+	__isl_give isl_set_list *isl_set_list_swap(
+		__isl_take isl_set_list *list,
+		unsigned pos1, unsigned pos2);
 	__isl_give isl_set_list *isl_set_list_set_set(
 		__isl_take isl_set_list *list, int index,
 		__isl_take isl_set *set);
@@ -7865,6 +7868,7 @@ C<isl_set_list_alloc> creates an empty list with an initial capacity
 for C<n> elements.  C<isl_set_list_insert> and C<isl_set_list_add>
 add elements to a list, increasing its capacity as needed.
 C<isl_set_list_from_set> creates a list with a single element.
+C<isl_set_list_swap> swaps the elements at the specified locations.
 
 Lists can be inspected using the following functions.
 

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -7845,6 +7845,8 @@ Lists can be created, copied, modified and freed using the following functions.
 	__isl_give isl_set_list *isl_set_list_swap(
 		__isl_take isl_set_list *list,
 		unsigned pos1, unsigned pos2);
+	__isl_give isl_set_list *isl_set_list_reverse(
+		__isl_take isl_set_list *list);
 	__isl_give isl_set_list *isl_set_list_set_set(
 		__isl_take isl_set_list *list, int index,
 		__isl_take isl_set *set);
@@ -7869,6 +7871,7 @@ for C<n> elements.  C<isl_set_list_insert> and C<isl_set_list_add>
 add elements to a list, increasing its capacity as needed.
 C<isl_set_list_from_set> creates a list with a single element.
 C<isl_set_list_swap> swaps the elements at the specified locations.
+C<isl_set_list_reverse> reverses the elements in the list.
 
 Lists can be inspected using the following functions.
 

--- a/include/isl/list.h
+++ b/include/isl/list.h
@@ -49,6 +49,8 @@ __isl_give isl_##EL##_list *isl_##EL##_list_drop(			\
 __isl_give isl_##EL##_list *isl_##EL##_list_swap(			\
 	__isl_take isl_##EL##_list *list, unsigned pos1,		\
 	unsigned pos2);							\
+__isl_give isl_##EL##_list *isl_##EL##_list_reverse(			\
+	__isl_take isl_##EL##_list *list);				\
 EXPORT									\
 __isl_give isl_##EL##_list *isl_##EL##_list_concat(			\
 	__isl_take isl_##EL##_list *list1,				\

--- a/include/isl/list.h
+++ b/include/isl/list.h
@@ -46,6 +46,9 @@ __isl_give isl_##EL##_list *isl_##EL##_list_insert(			\
 EXPORT									\
 __isl_give isl_##EL##_list *isl_##EL##_list_drop(			\
 	__isl_take isl_##EL##_list *list, unsigned first, unsigned n);	\
+__isl_give isl_##EL##_list *isl_##EL##_list_swap(			\
+	__isl_take isl_##EL##_list *list, unsigned pos1,		\
+	unsigned pos2);							\
 EXPORT									\
 __isl_give isl_##EL##_list *isl_##EL##_list_concat(			\
 	__isl_take isl_##EL##_list *list1,				\

--- a/include/isl/list.h
+++ b/include/isl/list.h
@@ -49,6 +49,7 @@ __isl_give isl_##EL##_list *isl_##EL##_list_drop(			\
 __isl_give isl_##EL##_list *isl_##EL##_list_swap(			\
 	__isl_take isl_##EL##_list *list, unsigned pos1,		\
 	unsigned pos2);							\
+EXPORT									\
 __isl_give isl_##EL##_list *isl_##EL##_list_reverse(			\
 	__isl_take isl_##EL##_list *list);				\
 EXPORT									\

--- a/isl_list_templ.c
+++ b/isl_list_templ.c
@@ -351,6 +351,18 @@ __isl_give LIST(EL) *FN(LIST(EL),swap)(__isl_take LIST(EL) *list,
 	return list;
 }
 
+/* Reverse the elements of "list".
+ */
+__isl_give LIST(EL) *FN(LIST(EL),reverse)(__isl_take LIST(EL) *list)
+{
+	int i, n;
+
+	n = FN(LIST(EL),n)(list);
+	for (i = 0; i < n - 1 - i; ++i)
+		list = FN(LIST(EL),swap)(list, i, n - 1 - i);
+	return list;
+}
+
 isl_stat FN(LIST(EL),foreach)(__isl_keep LIST(EL) *list,
 	isl_stat (*fn)(__isl_take EL *el, void *user), void *user)
 {

--- a/isl_list_templ.c
+++ b/isl_list_templ.c
@@ -335,6 +335,22 @@ static __isl_give LIST(EL) *FN(FN(LIST(EL),restore),BASE)(
 	return FN(FN(LIST(EL),set),BASE)(list, index, el);
 }
 
+/* Swap the elements of "list" in positions "pos1" and "pos2".
+ */
+__isl_give LIST(EL) *FN(LIST(EL),swap)(__isl_take LIST(EL) *list,
+	unsigned pos1, unsigned pos2)
+{
+	EL *el1, *el2;
+
+	if (pos1 == pos2)
+		return list;
+	el1 = FN(FN(LIST(EL),take),BASE)(list, pos1);
+	el2 = FN(FN(LIST(EL),take),BASE)(list, pos2);
+	list = FN(FN(LIST(EL),restore),BASE)(list, pos1, el2);
+	list = FN(FN(LIST(EL),restore),BASE)(list, pos2, el1);
+	return list;
+}
+
 isl_stat FN(LIST(EL),foreach)(__isl_keep LIST(EL) *list,
 	isl_stat (*fn)(__isl_take EL *el, void *user), void *user)
 {


### PR DESCRIPTION
This will be used to reverse the members extracted from a band for mapping to threads.