### PR TITLE
drop export of some functions with isl_dim_type argument

### DIFF
--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -35,9 +35,7 @@ __isl_null isl_aff *isl_aff_free(__isl_take isl_aff *aff);
 isl_ctx *isl_aff_get_ctx(__isl_keep isl_aff *aff);
 uint32_t isl_aff_get_hash(__isl_keep isl_aff *aff);
 
-__isl_export
 int isl_aff_dim(__isl_keep isl_aff *aff, enum isl_dim_type type);
-__isl_export
 isl_bool isl_aff_involves_dims(__isl_keep isl_aff *aff,
 	enum isl_dim_type type, unsigned first, unsigned n);
 
@@ -53,7 +51,6 @@ const char *isl_aff_get_dim_name(__isl_keep isl_aff *aff,
 	enum isl_dim_type type, unsigned pos);
 __isl_export
 __isl_give isl_val *isl_aff_get_constant_val(__isl_keep isl_aff *aff);
-__isl_export
 __isl_give isl_val *isl_aff_get_coefficient_val(__isl_keep isl_aff *aff,
 	enum isl_dim_type type, int pos);
 int isl_aff_coefficient_sgn(__isl_keep isl_aff *aff,
@@ -65,10 +62,8 @@ __isl_give isl_aff *isl_aff_set_constant_si(__isl_take isl_aff *aff, int v);
 __isl_export
 __isl_give isl_aff *isl_aff_set_constant_val(__isl_take isl_aff *aff,
 	__isl_take isl_val *v);
-__isl_export
 __isl_give isl_aff *isl_aff_set_coefficient_si(__isl_take isl_aff *aff,
 	enum isl_dim_type type, int pos, int v);
-__isl_export
 __isl_give isl_aff *isl_aff_set_coefficient_val(__isl_take isl_aff *aff,
 	enum isl_dim_type type, int pos, __isl_take isl_val *v);
 __isl_export
@@ -84,13 +79,10 @@ __isl_give isl_aff *isl_aff_add_coefficient_val(__isl_take isl_aff *aff,
 
 isl_bool isl_aff_is_cst(__isl_keep isl_aff *aff);
 
-__isl_export                                                            \
 __isl_give isl_aff *isl_aff_set_tuple_id(__isl_take isl_aff *aff,
 	enum isl_dim_type type, __isl_take isl_id *id);
-__isl_export
 __isl_give isl_aff *isl_aff_set_dim_name(__isl_take isl_aff *aff,
 	enum isl_dim_type type, unsigned pos, const char *s);
-__isl_export
 __isl_give isl_aff *isl_aff_set_dim_id(__isl_take isl_aff *aff,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
 
@@ -236,13 +228,10 @@ __isl_give isl_pw_aff *isl_set_indicator_function(__isl_take isl_set *set);
 
 const char *isl_pw_aff_get_dim_name(__isl_keep isl_pw_aff *pa,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 isl_bool isl_pw_aff_has_dim_id(__isl_keep isl_pw_aff *pa,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_id *isl_pw_aff_get_dim_id(__isl_keep isl_pw_aff *pa,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_pw_aff *isl_pw_aff_set_dim_id(__isl_take isl_pw_aff *pma,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
 
@@ -271,7 +260,6 @@ __isl_give isl_pw_aff *isl_pw_aff_union_add(__isl_take isl_pw_aff *pwaff1,
 __isl_give isl_pw_aff *isl_pw_aff_copy(__isl_keep isl_pw_aff *pwaff);
 __isl_null isl_pw_aff *isl_pw_aff_free(__isl_take isl_pw_aff *pwaff);
 
-__isl_export
 unsigned isl_pw_aff_dim(__isl_keep isl_pw_aff *pwaff, enum isl_dim_type type);
 isl_bool isl_pw_aff_involves_param_id(__isl_keep isl_pw_aff *pa,
 	__isl_keep isl_id *id);
@@ -291,16 +279,12 @@ __isl_give isl_pw_aff *isl_pw_aff_align_params(__isl_take isl_pw_aff *pwaff,
 __isl_give isl_pw_aff *isl_pw_aff_drop_unused_params(
 	__isl_take isl_pw_aff *pa);
 
-__isl_export
 isl_bool isl_pw_aff_has_tuple_id(__isl_keep isl_pw_aff *pa,
 	enum isl_dim_type type);
-__isl_export
 __isl_give isl_id *isl_pw_aff_get_tuple_id(__isl_keep isl_pw_aff *pa,
 	enum isl_dim_type type);
-__isl_export
 __isl_give isl_pw_aff *isl_pw_aff_set_tuple_id(__isl_take isl_pw_aff *pwaff,
 	enum isl_dim_type type, __isl_take isl_id *id);
-__isl_export
 __isl_give isl_pw_aff *isl_pw_aff_reset_tuple_id(__isl_take isl_pw_aff *pa,
 	enum isl_dim_type type);
 __isl_give isl_pw_aff *isl_pw_aff_reset_user(__isl_take isl_pw_aff *pa);
@@ -474,7 +458,6 @@ __isl_export
 __isl_give isl_multi_aff *isl_multi_aff_domain_map(__isl_take isl_space *space);
 __isl_export
 __isl_give isl_multi_aff *isl_multi_aff_range_map(__isl_take isl_space *space);
-__isl_export
 __isl_give isl_multi_aff *isl_multi_aff_project_out_map(
 	__isl_take isl_space *space, enum isl_dim_type type,
 	unsigned first, unsigned n);
@@ -530,7 +513,6 @@ __isl_give isl_pw_multi_aff *isl_pw_multi_aff_identity(
 	__isl_take isl_space *space);
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_range_map(
 	__isl_take isl_space *space);
-__isl_export
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_project_out_map(
 	__isl_take isl_space *space, enum isl_dim_type type,
 	unsigned first, unsigned n);
@@ -547,7 +529,6 @@ __isl_give isl_pw_multi_aff *isl_pw_multi_aff_copy(
 __isl_null isl_pw_multi_aff *isl_pw_multi_aff_free(
 	__isl_take isl_pw_multi_aff *pma);
 
-__isl_export
 unsigned isl_pw_multi_aff_dim(__isl_keep isl_pw_multi_aff *pma,
 	enum isl_dim_type type);
 isl_bool isl_pw_multi_aff_involves_param_id(__isl_keep isl_pw_multi_aff *pma,
@@ -578,14 +559,11 @@ const char *isl_pw_multi_aff_get_tuple_name(__isl_keep isl_pw_multi_aff *pma,
 __isl_export
 __isl_give isl_id *isl_pw_multi_aff_get_tuple_id(
 	__isl_keep isl_pw_multi_aff *pma, enum isl_dim_type type);
-__isl_export
 isl_bool isl_pw_multi_aff_has_tuple_id(__isl_keep isl_pw_multi_aff *pma,
 	enum isl_dim_type type);
-__isl_export
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_set_tuple_id(
 	__isl_take isl_pw_multi_aff *pma,
 	enum isl_dim_type type, __isl_take isl_id *id);
-__isl_export
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_reset_tuple_id(
 	__isl_take isl_pw_multi_aff *pma, enum isl_dim_type type);
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_reset_user(
@@ -611,11 +589,9 @@ __isl_give isl_pw_multi_aff *isl_pw_multi_aff_multi_val_on_domain(
 
 const char *isl_pw_multi_aff_get_dim_name(__isl_keep isl_pw_multi_aff *pma,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_id *isl_pw_multi_aff_get_dim_id(
 	__isl_keep isl_pw_multi_aff *pma, enum isl_dim_type type,
 	unsigned pos);
-__isl_export
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_set_dim_id(
 	__isl_take isl_pw_multi_aff *pma,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
@@ -773,7 +749,6 @@ __isl_give isl_space *isl_union_pw_multi_aff_get_space(
 __isl_give isl_pw_multi_aff_list *isl_union_pw_multi_aff_get_pw_multi_aff_list(
 	__isl_keep isl_union_pw_multi_aff *upma);
 
-__isl_export
 unsigned isl_union_pw_multi_aff_dim(__isl_keep isl_union_pw_multi_aff *upma,
 	enum isl_dim_type type);
 isl_bool isl_union_pw_multi_aff_involves_param_id(
@@ -972,7 +947,6 @@ __isl_export
 __isl_give isl_pw_aff_list *isl_union_pw_aff_get_pw_aff_list(
 	__isl_keep isl_union_pw_aff *upa);
 
-__isl_export
 unsigned isl_union_pw_aff_dim(__isl_keep isl_union_pw_aff *upa,
 	enum isl_dim_type type);
 __isl_overload

--- a/include/isl/constraint.h
+++ b/include/isl/constraint.h
@@ -105,13 +105,11 @@ __isl_export
 isl_bool isl_constraint_involves_dims(__isl_keep isl_constraint *constraint,
 	enum isl_dim_type type, unsigned first, unsigned n);
 
-__isl_export
 const char *isl_constraint_get_dim_name(__isl_keep isl_constraint *constraint,
 	enum isl_dim_type type, unsigned pos);
 __isl_export
 __isl_give isl_val *isl_constraint_get_constant_val(
 	__isl_keep isl_constraint *constraint);
-__isl_export
 __isl_give isl_val *isl_constraint_get_coefficient_val(
 	__isl_keep isl_constraint *constraint, enum isl_dim_type type, int pos);
 __isl_export
@@ -124,7 +122,6 @@ __isl_export
 __isl_give isl_constraint *isl_constraint_set_coefficient_si(
 	__isl_take isl_constraint *constraint,
 	enum isl_dim_type type, int pos, int v);
-__isl_export
 __isl_give isl_constraint *isl_constraint_set_coefficient_val(
 	__isl_take isl_constraint *constraint,
 	enum isl_dim_type type, int pos, __isl_take isl_val *v);
@@ -143,7 +140,6 @@ int isl_constraint_is_div_constraint(__isl_keep isl_constraint *constraint);
 __isl_export
 isl_bool isl_constraint_is_lower_bound(__isl_keep isl_constraint *constraint,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 isl_bool isl_constraint_is_upper_bound(__isl_keep isl_constraint *constraint,
 	enum isl_dim_type type, unsigned pos);
 

--- a/include/isl/local_space.h
+++ b/include/isl/local_space.h
@@ -28,31 +28,23 @@ isl_bool isl_local_space_is_params(__isl_keep isl_local_space *ls);
 __isl_export
 isl_bool isl_local_space_is_set(__isl_keep isl_local_space *ls);
 
-__isl_export
 __isl_give isl_local_space *isl_local_space_set_tuple_id(
 	__isl_take isl_local_space *ls,
 	enum isl_dim_type type, __isl_take isl_id *id);
 
-__isl_export
 int isl_local_space_dim(__isl_keep isl_local_space *ls,
 	enum isl_dim_type type);
-__isl_export
 isl_bool isl_local_space_has_dim_name(__isl_keep isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 const char *isl_local_space_get_dim_name(__isl_keep isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_local_space *isl_local_space_set_dim_name(
 	__isl_take isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos, const char *s);
-__isl_export
 isl_bool isl_local_space_has_dim_id(__isl_keep isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_id *isl_local_space_get_dim_id(__isl_keep isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_local_space *isl_local_space_set_dim_id(
 	__isl_take isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
@@ -74,14 +66,11 @@ __isl_give isl_local_space *isl_local_space_range(
 __isl_export
 __isl_give isl_local_space *isl_local_space_from_domain(
 	__isl_take isl_local_space *ls);
-__isl_export
 __isl_give isl_local_space *isl_local_space_add_dims(
 	__isl_take isl_local_space *ls, enum isl_dim_type type, unsigned n);
-__isl_export
 __isl_give isl_local_space *isl_local_space_drop_dims(
 	__isl_take isl_local_space *ls,
 	enum isl_dim_type type, unsigned first, unsigned n);
-__isl_export
 __isl_give isl_local_space *isl_local_space_insert_dims(
 	__isl_take isl_local_space *ls,
 	enum isl_dim_type type, unsigned first, unsigned n);

--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -38,7 +38,6 @@ unsigned isl_basic_map_n_param(__isl_keep const isl_basic_map *bmap);
 ISL_DEPRECATED
 unsigned isl_basic_map_n_div(__isl_keep const isl_basic_map *bmap);
 unsigned isl_basic_map_total_dim(__isl_keep const isl_basic_map *bmap);
-__isl_export
 unsigned isl_basic_map_dim(__isl_keep isl_basic_map *bmap,
 				enum isl_dim_type type);
 
@@ -66,16 +65,12 @@ __isl_give isl_local_space *isl_basic_map_get_local_space(
 
 __isl_give isl_basic_map *isl_basic_map_set_tuple_name(
 	__isl_take isl_basic_map *bmap, enum isl_dim_type type, const char *s);
-__isl_export
 const char *isl_basic_map_get_tuple_name(__isl_keep isl_basic_map *bmap,
 	enum isl_dim_type type);
-__isl_export
 isl_bool isl_map_has_tuple_name(__isl_keep isl_map *map,
 	enum isl_dim_type type);
-__isl_export
 const char *isl_map_get_tuple_name(__isl_keep isl_map *map,
 	enum isl_dim_type type);
-__isl_export
 __isl_give isl_map *isl_map_set_tuple_name(__isl_take isl_map *map,
 	enum isl_dim_type type, const char *s);
 const char *isl_basic_map_get_dim_name(__isl_keep isl_basic_map *bmap,
@@ -93,24 +88,19 @@ __isl_give isl_map *isl_map_set_dim_name(__isl_take isl_map *map,
 __isl_give isl_basic_map *isl_basic_map_set_tuple_id(
 	__isl_take isl_basic_map *bmap,
 	enum isl_dim_type type, __isl_take isl_id *id);
-__isl_export
 __isl_give isl_map *isl_map_set_dim_id(__isl_take isl_map *map,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
 isl_bool isl_basic_map_has_dim_id(__isl_keep isl_basic_map *bmap,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 isl_bool isl_map_has_dim_id(__isl_keep isl_map *map,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_id *isl_map_get_dim_id(__isl_keep isl_map *map,
 	enum isl_dim_type type, unsigned pos);
 __isl_export
 __isl_give isl_map *isl_map_set_tuple_id(__isl_take isl_map *map,
 	enum isl_dim_type type, __isl_take isl_id *id);
-__isl_export
 __isl_give isl_map *isl_map_reset_tuple_id(__isl_take isl_map *map,
 	enum isl_dim_type type);
-__isl_export
 isl_bool isl_map_has_tuple_id(__isl_keep isl_map *map, enum isl_dim_type type);
 __isl_export
 __isl_give isl_id *isl_map_get_tuple_id(__isl_keep isl_map *map,
@@ -443,13 +433,11 @@ __isl_export
 __isl_give isl_basic_map *isl_map_polyhedral_hull(__isl_take isl_map *map);
 __isl_give isl_basic_map *isl_basic_map_add_dims(__isl_take isl_basic_map *bmap,
     enum isl_dim_type type, unsigned n);
-__isl_export
 __isl_give isl_map *isl_map_add_dims(__isl_take isl_map *map,
 		enum isl_dim_type type, unsigned n);
 __isl_give isl_basic_map *isl_basic_map_insert_dims(
 	__isl_take isl_basic_map *bmap, enum isl_dim_type type,
 	unsigned pos, unsigned n);
-__isl_export
 __isl_give isl_map *isl_map_insert_dims(__isl_take isl_map *map,
 		enum isl_dim_type type, unsigned pos, unsigned n);
 __isl_give isl_basic_map *isl_basic_map_move_dims(
@@ -459,7 +447,6 @@ __isl_give isl_basic_map *isl_basic_map_move_dims(
 __isl_give isl_map *isl_map_move_dims(__isl_take isl_map *map,
 	enum isl_dim_type dst_type, unsigned dst_pos,
 	enum isl_dim_type src_type, unsigned src_pos, unsigned n);
-__isl_export
 __isl_give isl_basic_map *isl_basic_map_project_out(
 		__isl_take isl_basic_map *bmap,
 		enum isl_dim_type type, unsigned first, unsigned n);
@@ -472,7 +459,6 @@ __isl_give isl_map *isl_map_remove_unknown_divs(__isl_take isl_map *map);
 __isl_give isl_map *isl_map_remove_divs(__isl_take isl_map *map);
 __isl_give isl_map *isl_map_eliminate(__isl_take isl_map *map,
 	enum isl_dim_type type, unsigned first, unsigned n);
-__isl_export
 __isl_give isl_map *isl_map_remove_dims(__isl_take isl_map *map,
 	enum isl_dim_type type, unsigned first, unsigned n);
 __isl_give isl_basic_map *isl_basic_map_remove_divs_involving_dims(

--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -43,18 +43,15 @@ isl_bool isl_multi_##BASE##_involves_nan(				\
 int isl_multi_##BASE##_find_dim_by_id(					\
 	__isl_keep isl_multi_##BASE *multi, enum isl_dim_type type,	\
 	__isl_keep isl_id *id);						\
-__isl_export                                                            \
 __isl_give isl_id *isl_multi_##BASE##_get_dim_id(			\
 	__isl_keep isl_multi_##BASE *multi,				\
 	enum isl_dim_type type, unsigned pos);				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_dim_name(		\
 	__isl_take isl_multi_##BASE *multi,				\
 	enum isl_dim_type type, unsigned pos, const char *s);		\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_dim_id(		\
 	__isl_take isl_multi_##BASE *multi,				\
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);	\
-__isl_export  								\
 const char *isl_multi_##BASE##_get_tuple_name(				\
 	__isl_keep isl_multi_##BASE *multi, enum isl_dim_type type);	\
 __isl_export								\
@@ -167,11 +164,9 @@ __isl_give isl_multi_##BASE *isl_multi_##BASE##_neg(		 	\
 isl_bool isl_multi_##BASE##_involves_dims(				\
 	__isl_keep isl_multi_##BASE *multi, enum isl_dim_type type,	\
 	unsigned first, unsigned n);					\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_insert_dims(		\
 	__isl_take isl_multi_##BASE *multi, enum isl_dim_type type,	\
 	unsigned first, unsigned n);					\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_add_dims(		\
 	__isl_take isl_multi_##BASE *multi, enum isl_dim_type type,	\
 	unsigned n);							\

--- a/include/isl/point.h
+++ b/include/isl/point.h
@@ -21,16 +21,13 @@ __isl_give isl_point *isl_point_zero(__isl_take isl_space *dim);
 __isl_give isl_point *isl_point_copy(__isl_keep isl_point *pnt);
 __isl_null isl_point *isl_point_free(__isl_take isl_point *pnt);
 
-__isl_export
 __isl_give isl_val *isl_point_get_coordinate_val(__isl_keep isl_point *pnt,
 	enum isl_dim_type type, int pos);
 __isl_give isl_point *isl_point_set_coordinate_val(__isl_take isl_point *pnt,
 	enum isl_dim_type type, int pos, __isl_take isl_val *v);
 
-__isl_export
 __isl_give isl_point *isl_point_add_ui(__isl_take isl_point *pnt,
 	enum isl_dim_type type, int pos, unsigned val);
-__isl_export
 __isl_give isl_point *isl_point_sub_ui(__isl_take isl_point *pnt,
 	enum isl_dim_type type, int pos, unsigned val);
 

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -30,7 +30,6 @@ unsigned isl_basic_set_n_dim(__isl_keep isl_basic_set *bset);
 __isl_export
 unsigned isl_basic_set_n_param(__isl_keep isl_basic_set *bset);
 unsigned isl_basic_set_total_dim(__isl_keep const isl_basic_set *bset);
-__isl_export
 unsigned isl_basic_set_dim(__isl_keep isl_basic_set *bset,
 				enum isl_dim_type type);
 
@@ -69,7 +68,6 @@ __isl_give isl_set *isl_set_set_tuple_name(__isl_take isl_set *set,
 	const char *s);
 const char *isl_basic_set_get_dim_name(__isl_keep isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_set_dim_name(
 	__isl_take isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos, const char *s);
@@ -81,7 +79,6 @@ __isl_export
 __isl_give isl_set *isl_set_set_dim_name(__isl_take isl_set *set,
 	enum isl_dim_type type, unsigned pos, const char *s);
 
-__isl_export
 __isl_give isl_id *isl_basic_set_get_dim_id(__isl_keep isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos);
 __isl_export
@@ -90,10 +87,8 @@ __isl_give isl_basic_set *isl_basic_set_set_tuple_id(
 __isl_export
 __isl_give isl_set *isl_set_set_dim_id(__isl_take isl_set *set,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
-__isl_export
 isl_bool isl_set_has_dim_id(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_id *isl_set_get_dim_id(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
 __isl_export
@@ -177,22 +172,18 @@ __isl_give isl_basic_set *isl_basic_set_fix_val(__isl_take isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_val *v);
 __isl_give isl_set *isl_set_fix_si(__isl_take isl_set *set,
 		enum isl_dim_type type, unsigned pos, int value);
-__isl_export
 __isl_give isl_set *isl_set_lower_bound_si(__isl_take isl_set *set,
 		enum isl_dim_type type, unsigned pos, int value);
 __isl_give isl_basic_set *isl_basic_set_lower_bound_val(
 	__isl_take isl_basic_set *bset, enum isl_dim_type type, unsigned pos,
 	__isl_take isl_val *value);
-__isl_export
 __isl_give isl_set *isl_set_lower_bound_val(__isl_take isl_set *set,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_val *value);
-__isl_export
 __isl_give isl_set *isl_set_upper_bound_si(__isl_take isl_set *set,
 	enum isl_dim_type type, unsigned pos, int value);
 __isl_give isl_basic_set *isl_basic_set_upper_bound_val(
 	__isl_take isl_basic_set *bset, enum isl_dim_type type, unsigned pos,
 	__isl_take isl_val *value);
-__isl_export
 __isl_give isl_set *isl_set_upper_bound_val(__isl_take isl_set *set,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_val *value);
 
@@ -351,10 +342,8 @@ struct isl_set *isl_set_fix_dim_si(struct isl_set *set,
 __isl_give isl_basic_set *isl_basic_set_insert_dims(
 	__isl_take isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos, unsigned n);
-__isl_export
 __isl_give isl_set *isl_set_insert_dims(__isl_take isl_set *set,
 		enum isl_dim_type type, unsigned pos, unsigned n);
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_add_dims(__isl_take isl_basic_set *bset,
 		enum isl_dim_type type, unsigned n);
 __isl_export
@@ -366,11 +355,9 @@ __isl_give isl_basic_set *isl_basic_set_move_dims(__isl_take isl_basic_set *bset
 __isl_give isl_set *isl_set_move_dims(__isl_take isl_set *set,
 	enum isl_dim_type dst_type, unsigned dst_pos,
 	enum isl_dim_type src_type, unsigned src_pos, unsigned n);
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_project_out(
 		__isl_take isl_basic_set *bset,
 		enum isl_dim_type type, unsigned first, unsigned n);
-__isl_export
 __isl_give isl_set *isl_set_project_out(__isl_take isl_set *set,
 		enum isl_dim_type type, unsigned first, unsigned n);
 __isl_give isl_map *isl_set_project_onto_map(__isl_take isl_set *set,
@@ -384,7 +371,6 @@ __isl_give isl_set *isl_set_eliminate(__isl_take isl_set *set,
 	enum isl_dim_type type, unsigned first, unsigned n);
 __isl_give isl_set *isl_set_eliminate_dims(__isl_take isl_set *set,
 		unsigned first, unsigned n);
-__isl_export
 __isl_give isl_set *isl_set_remove_dims(__isl_take isl_set *bset,
 	enum isl_dim_type type, unsigned first, unsigned n);
 __isl_give isl_basic_set *isl_basic_set_remove_divs_involving_dims(
@@ -412,13 +398,11 @@ __isl_give isl_set *isl_set_drop_constraints_not_involving_dims(
 	__isl_take isl_set *set,
 	enum isl_dim_type type, unsigned first, unsigned n);
 
-__isl_export
 isl_bool isl_basic_set_involves_dims(__isl_keep isl_basic_set *bset,
 	enum isl_dim_type type, unsigned first, unsigned n);
 __isl_overload
 isl_bool isl_set_involves_param_id(__isl_keep isl_set *set,
 	__isl_keep isl_id *id);
-__isl_export
 isl_bool isl_set_involves_dims(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned first, unsigned n);
 
@@ -466,7 +450,6 @@ isl_bool isl_set_dim_is_bounded(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
 isl_bool isl_set_dim_has_lower_bound(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 isl_bool isl_set_dim_has_upper_bound(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
 isl_bool isl_set_dim_has_any_lower_bound(__isl_keep isl_set *set,

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -44,10 +44,8 @@ __isl_give isl_space *isl_space_add_param_id(__isl_take isl_space *space,
 __isl_export
 __isl_give isl_space *isl_space_set_tuple_name(__isl_take isl_space *dim,
 	enum isl_dim_type type, const char *s);
-__isl_export
 isl_bool isl_space_has_tuple_name(__isl_keep isl_space *space,
 	enum isl_dim_type type);
-__isl_export
 __isl_keep const char *isl_space_get_tuple_name(__isl_keep isl_space *dim,
 				 enum isl_dim_type type);
 __isl_export
@@ -67,7 +65,6 @@ __isl_give isl_space *isl_space_reset_user(__isl_take isl_space *space);
 __isl_export
 __isl_give isl_space *isl_space_set_dim_id(__isl_take isl_space *dim,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
-__isl_export
 isl_bool isl_space_has_dim_id(__isl_keep isl_space *dim,
 	enum isl_dim_type type, unsigned pos);
 __isl_export
@@ -80,7 +77,6 @@ __isl_export
 int isl_space_find_dim_by_name(__isl_keep isl_space *space,
 	enum isl_dim_type type, const char *name);
 
-__isl_export
 isl_bool isl_space_has_dim_name(__isl_keep isl_space *space,
 	enum isl_dim_type type, unsigned pos);
 __isl_export
@@ -137,7 +133,6 @@ __isl_export
 __isl_give isl_space *isl_space_map_from_domain_and_range(
 	__isl_take isl_space *domain, __isl_take isl_space *range);
 __isl_give isl_space *isl_space_reverse(__isl_take isl_space *dim);
-__isl_export
 __isl_give isl_space *isl_space_drop_dims(__isl_take isl_space *dim,
 	enum isl_dim_type type, unsigned first, unsigned num);
 ISL_DEPRECATED

--- a/include/isl/union_map.h
+++ b/include/isl/union_map.h
@@ -13,7 +13,6 @@
 extern "C" {
 #endif
 
-__isl_export
 unsigned isl_union_map_dim(__isl_keep isl_union_map *umap,
 	enum isl_dim_type type);
 isl_bool isl_union_map_involves_param_id(__isl_keep isl_union_map *umap,
@@ -210,7 +209,6 @@ __isl_give isl_union_map *isl_union_map_deltas_map(
 __isl_export
 __isl_give isl_union_map *isl_union_set_identity(__isl_take isl_union_set *uset);
 
-__isl_export
 __isl_give isl_union_map *isl_union_map_project_out(
 	__isl_take isl_union_map *umap,
 	enum isl_dim_type type, unsigned first, unsigned n);

--- a/include/isl/union_set.h
+++ b/include/isl/union_set.h
@@ -8,7 +8,6 @@
 extern "C" {
 #endif
 
-__isl_export
 unsigned isl_union_set_dim(__isl_keep isl_union_set *uset,
 	enum isl_dim_type type);
 __isl_overload
@@ -99,7 +98,6 @@ __isl_give isl_union_set *isl_union_set_preimage_union_pw_multi_aff(
 	__isl_take isl_union_set *uset,
 	__isl_take isl_union_pw_multi_aff *upma);
 
-__isl_export
 __isl_give isl_union_set *isl_union_set_project_out(
 	__isl_take isl_union_set *uset,
 	enum isl_dim_type type, unsigned first, unsigned n);


### PR DESCRIPTION
These functions were never meant to be exported.
There are still some exported functions left, but this
at least removes those that are not currently used
to prevent anyone from starting to use them.