### PR TITLE
add isl_multi_*_size

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -2944,6 +2944,19 @@ the following functions.
 	isl_multi_union_pw_aff_free(
 		__isl_take isl_multi_union_pw_aff *mupa);
 
+The number of base expressions in a multiple
+expression can be obtained using the following functions.
+
+	#include <isl/val.h>
+	int isl_multi_val_size(__isl_keep isl_multi_val *mv);
+
+	#include <isl/aff.h>
+	int isl_multi_aff_size(__isl_keep isl_multi_aff *multi);
+	int isl_multi_pw_aff_size(
+		__isl_keep isl_multi_pw_aff *mpa);
+	int isl_multi_union_pw_aff_size(
+		__isl_keep isl_multi_union_pw_aff *mupa);
+
 The base expression at a given position of a multiple
 expression can be extracted using the following functions.
 

--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -78,6 +78,7 @@ __isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_drop_dims(		\
 	__isl_take isl_multi_##BASE *multi, enum isl_dim_type type,	\
 	unsigned first, unsigned n);					\
+__isl_export                                                            \
 int isl_multi_##BASE##_size(__isl_keep isl_multi_##BASE *multi);	\
 __isl_export                                                            \
 __isl_give isl_##BASE *isl_multi_##BASE##_get_##BASE(			\

--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -78,6 +78,7 @@ __isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_drop_dims(		\
 	__isl_take isl_multi_##BASE *multi, enum isl_dim_type type,	\
 	unsigned first, unsigned n);					\
+int isl_multi_##BASE##_size(__isl_keep isl_multi_##BASE *multi);	\
 __isl_export                                                            \
 __isl_give isl_##BASE *isl_multi_##BASE##_get_##BASE(			\
 	__isl_keep isl_multi_##BASE *multi, int pos);			\

--- a/isl_multi_templ.c
+++ b/isl_multi_templ.c
@@ -228,6 +228,13 @@ __isl_give isl_id *FN(MULTI(BASE),get_tuple_id)(__isl_keep MULTI(BASE) *multi,
 	return multi ? isl_space_get_tuple_id(multi->space, type) : NULL;
 }
 
+/* Return the number of base expressions in "multi".
+ */
+int FN(MULTI(BASE),size)(__isl_keep MULTI(BASE) *multi)
+{
+	return multi ? multi->n : -1;
+}
+
 __isl_give EL *FN(FN(MULTI(BASE),get),BASE)(__isl_keep MULTI(BASE) *multi,
 	int pos)
 {


### PR DESCRIPTION
It was already possible to obtain the number of base expressions
in a multiple expression, but only through a rather awkward interface.
In particular, it is also possible to obtained this number
by calling isl_multi_*_dim.  However, the dimension type that
needs to be specified depends on whether the multi expression
lives in a set or a map space.  Furthermore, for such a basic
property of a multi expression, the user should not have
to bother with any dimension type.

It is not entirely obvious what would be the best name
for this function.  Since a multi-expression is
a (possibly structured) tuple, valid names
would appear to be "length" or "size".
This commit picks "size".