### PR TITLE
[cmake] require C++11 flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.2)
 project(isl)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set(CMAKE_CXX_STANDARD 11)
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/isl/isl_ctx.c")
   set(ISL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/isl")
 elseif (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/isl_ctx.c")


### PR DESCRIPTION
When building with C++ bindings, C++11 support is mandatory to compile
bindings tests.  Original CMakeLists.txt did not include the command to
request the C++ compiler to use the C++11 standard, leading to
compilation errors with older compilers such as GCC-5.4.  Require C++11
flags from cmake.