### PR TITLE
drop export of more functions with isl_dim_type argument

### DIFF
--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -60,7 +60,6 @@ isl_bool isl_multi_##BASE##_has_tuple_id(				\
 __isl_export                                                            \
 __isl_give isl_id *isl_multi_##BASE##_get_tuple_id(			\
 	__isl_keep isl_multi_##BASE *multi, enum isl_dim_type type);	\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_tuple_name(		\
 	__isl_take isl_multi_##BASE *multi,				\
 	enum isl_dim_type type, const char *s);				\

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -75,7 +75,6 @@ isl_bool isl_set_has_dim_name(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
 const char *isl_set_get_dim_name(__isl_keep isl_set *set,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_set *isl_set_set_dim_name(__isl_take isl_set *set,
 	enum isl_dim_type type, unsigned pos, const char *s);
 

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -48,7 +48,6 @@ isl_bool isl_space_has_tuple_name(__isl_keep isl_space *space,
 	enum isl_dim_type type);
 __isl_keep const char *isl_space_get_tuple_name(__isl_keep isl_space *dim,
 				 enum isl_dim_type type);
-__isl_export
 __isl_give isl_space *isl_space_set_tuple_id(__isl_take isl_space *dim,
 	enum isl_dim_type type, __isl_take isl_id *id);
 __isl_export

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -77,7 +77,6 @@ int isl_space_find_dim_by_name(__isl_keep isl_space *space,
 
 isl_bool isl_space_has_dim_name(__isl_keep isl_space *space,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_space *isl_space_set_dim_name(__isl_take isl_space *dim,
 				 enum isl_dim_type type, unsigned pos,
 				 __isl_keep const char *name);

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -66,7 +66,6 @@ __isl_give isl_space *isl_space_set_dim_id(__isl_take isl_space *dim,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
 isl_bool isl_space_has_dim_id(__isl_keep isl_space *dim,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_id *isl_space_get_dim_id(__isl_keep isl_space *dim,
 	enum isl_dim_type type, unsigned pos);
 

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -90,7 +90,6 @@ __isl_keep const char *isl_space_get_dim_name(__isl_keep isl_space *dim,
 ISL_DEPRECATED
 __isl_give isl_space *isl_space_extend(__isl_take isl_space *dim,
 			unsigned nparam, unsigned n_in, unsigned n_out);
-__isl_export
 __isl_give isl_space *isl_space_add_dims(__isl_take isl_space *space,
 	enum isl_dim_type type, unsigned n);
 __isl_give isl_space *isl_space_move_dims(__isl_take isl_space *space,


### PR DESCRIPTION
These functions were never meant to be exported.
There are still some exported functions left, but this
at least removes those that are not currently used
to prevent anyone from starting to use them.
