### PR TITLE
drop export of more functions with isl_dim_type argument

### DIFF
--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -140,7 +140,6 @@ __isl_give isl_aff *isl_aff_add_dims(__isl_take isl_aff *aff,
 __isl_give isl_aff *isl_aff_move_dims(__isl_take isl_aff *aff,
 	enum isl_dim_type dst_type, unsigned dst_pos,
 	enum isl_dim_type src_type, unsigned src_pos, unsigned n);
-__isl_export
 __isl_give isl_aff *isl_aff_drop_dims(__isl_take isl_aff *aff,
 	enum isl_dim_type type, unsigned first, unsigned n);
 __isl_export

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -73,7 +73,6 @@ __isl_give isl_aff *isl_aff_add_constant_si(__isl_take isl_aff *aff, int v);
 __isl_give isl_aff *isl_aff_add_constant_val(__isl_take isl_aff *aff,
 	__isl_take isl_val *v);
 __isl_give isl_aff *isl_aff_add_constant_num_si(__isl_take isl_aff *aff, int v);
-__isl_export
 __isl_give isl_aff *isl_aff_add_coefficient_si(__isl_take isl_aff *aff,
 	enum isl_dim_type type, int pos, int v);
 __isl_give isl_aff *isl_aff_add_coefficient_val(__isl_take isl_aff *aff,

--- a/include/isl/constraint.h
+++ b/include/isl/constraint.h
@@ -136,7 +136,6 @@ isl_bool isl_constraint_is_equality(__isl_keep isl_constraint *constraint);
 __isl_export
 int isl_constraint_is_div_constraint(__isl_keep isl_constraint *constraint);
 
-__isl_export
 isl_bool isl_constraint_is_lower_bound(__isl_keep isl_constraint *constraint,
 	enum isl_dim_type type, unsigned pos);
 isl_bool isl_constraint_is_upper_bound(__isl_keep isl_constraint *constraint,

--- a/include/isl/constraint.h
+++ b/include/isl/constraint.h
@@ -146,7 +146,6 @@ __isl_give isl_basic_map *isl_basic_map_from_constraint(
 __isl_give isl_basic_set *isl_basic_set_from_constraint(
 	__isl_take isl_constraint *constraint);
 
-__isl_export
 __isl_give isl_aff *isl_constraint_get_bound(
 	__isl_keep isl_constraint *constraint, enum isl_dim_type type, int pos);
 __isl_export

--- a/include/isl/constraint.h
+++ b/include/isl/constraint.h
@@ -101,7 +101,6 @@ __isl_export
 int isl_constraint_dim(__isl_keep isl_constraint *constraint,
 	enum isl_dim_type type);
 
-__isl_export
 isl_bool isl_constraint_involves_dims(__isl_keep isl_constraint *constraint,
 	enum isl_dim_type type, unsigned first, unsigned n);
 

--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -449,7 +449,6 @@ __isl_give isl_map *isl_map_move_dims(__isl_take isl_map *map,
 __isl_give isl_basic_map *isl_basic_map_project_out(
 		__isl_take isl_basic_map *bmap,
 		enum isl_dim_type type, unsigned first, unsigned n);
-__isl_export
 __isl_give isl_map *isl_map_project_out(__isl_take isl_map *map,
 		enum isl_dim_type type, unsigned first, unsigned n);
 __isl_give isl_basic_map *isl_basic_map_remove_divs(

--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -48,7 +48,6 @@ ISL_DEPRECATED
 unsigned isl_map_n_out(__isl_keep const isl_map *map);
 ISL_DEPRECATED
 unsigned isl_map_n_param(__isl_keep const isl_map *map);
-__isl_export
 unsigned isl_map_dim(__isl_keep isl_map *map, enum isl_dim_type type);
 
 isl_ctx *isl_basic_map_get_ctx(__isl_keep isl_basic_map *bmap);

--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -128,7 +128,6 @@ isl_bool isl_multi_##BASE##_involves_nan(				\
 	__isl_keep isl_multi_##BASE *multi);
 
 #define ISL_DECLARE_MULTI_DROP_DIMS(BASE)				\
-__isl_export                                                            \
 unsigned isl_multi_##BASE##_dim(__isl_keep isl_multi_##BASE *multi,	\
 	enum isl_dim_type type);					\
 __isl_export								\

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -50,7 +50,6 @@ __isl_keep const char *isl_space_get_tuple_name(__isl_keep isl_space *dim,
 				 enum isl_dim_type type);
 __isl_give isl_space *isl_space_set_tuple_id(__isl_take isl_space *dim,
 	enum isl_dim_type type, __isl_take isl_id *id);
-__isl_export
 __isl_give isl_space *isl_space_reset_tuple_id(__isl_take isl_space *dim,
 	enum isl_dim_type type);
 __isl_export


### PR DESCRIPTION
These functions were never meant to be exported.
There are still some exported functions left, but this
at least removes those that are not currently used
to prevent anyone from starting to use them.