### PR TITLE
add isl_space_has_param_id

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -1211,6 +1211,14 @@ Additional parameters can be added to a space using the following function.
 If a parameter with the given identifier already appears in the space,
 then it is not added again.
 
+The presence of a parameter in a space can be checked using
+the following function.
+
+	#include <isl/space.h>
+	isl_bool isl_space_has_param_id(
+		__isl_keep isl_space *space,
+		__isl_keep isl_id *id);
+
 The identifiers or names of the individual dimensions of spaces
 may be set or read off using the following functions on spaces
 or objects that live in spaces.

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -37,6 +37,8 @@ __isl_export
 isl_bool isl_space_is_set(__isl_keep isl_space *space);
 isl_bool isl_space_is_map(__isl_keep isl_space *space);
 
+isl_bool isl_space_has_param_id(__isl_keep isl_space *space,
+	__isl_keep isl_id *id);
 __isl_overload
 __isl_give isl_space *isl_space_add_param_id(__isl_take isl_space *space,
 	__isl_take isl_id *id);

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -37,6 +37,7 @@ __isl_export
 isl_bool isl_space_is_set(__isl_keep isl_space *space);
 isl_bool isl_space_is_map(__isl_keep isl_space *space);
 
+__isl_overload
 isl_bool isl_space_has_param_id(__isl_keep isl_space *space,
 	__isl_keep isl_id *id);
 __isl_overload

--- a/isl_space.c
+++ b/isl_space.c
@@ -976,6 +976,17 @@ error:
 	return NULL;
 }
 
+/* Does "id" appear as a parameter in "space"?
+ */
+isl_bool isl_space_has_param_id(__isl_keep isl_space *space,
+	__isl_keep isl_id *id)
+{
+	if (!space || !id)
+		return isl_bool_error;
+
+	return isl_space_find_dim_by_id(space, isl_dim_param, id) >= 0;
+}
+
 /* Add a parameter with identifier "id" to "space", provided
  * it does not already appear in "space".
  */


### PR DESCRIPTION
This convenience function allows the user to check whether
a parameter is present in a space without having to call
isl_space_find_dim_by_id.  In particular, the user shouldn't
be forced to think of parameters as having a position.

Signed-off-by: Sven Verdoolaege <sven.verdoolaege@gmail.com>