### PR TITLE
isl_map_list: declare exported list functions

### DIFF
--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -740,7 +740,7 @@ __isl_give isl_pw_aff *isl_map_dim_min(__isl_take isl_map *map, int pos);
 __isl_give isl_pw_aff *isl_map_dim_max(__isl_take isl_map *map, int pos);
 
 ISL_DECLARE_EXPORTED_LIST_FN(basic_map)
-ISL_DECLARE_LIST_FN(map)
+ISL_DECLARE_EXPORTED_LIST_FN(map)
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
This is necessary to make isl::map_list, exported before, compatible
with the C++ iterator template.