### PR TITLE
Revert "create and export isl_union_set_max_multi_union_pw_aff"

### DIFF
--- a/include/isl/ilp.h
+++ b/include/isl/ilp.h
@@ -29,12 +29,8 @@ __isl_give isl_val *isl_set_min_val(__isl_keep isl_set *set,
 __isl_export
 __isl_give isl_val *isl_set_max_val(__isl_keep isl_set *set,
 	__isl_keep isl_aff *obj);
-__isl_export
 __isl_give isl_multi_val *isl_union_set_min_multi_union_pw_aff(
-	__isl_keep isl_union_set *uset, __isl_keep isl_multi_union_pw_aff *obj);
-__isl_export
-__isl_give isl_multi_val *isl_union_set_max_multi_union_pw_aff(
-	__isl_keep isl_union_set *uset, __isl_keep isl_multi_union_pw_aff *obj);
+	__isl_keep isl_union_set *set, __isl_keep isl_multi_union_pw_aff *obj);
 
 __isl_export
 __isl_give isl_val *isl_basic_set_dim_max_val(__isl_take isl_basic_set *bset,

--- a/isl_ilp.c
+++ b/isl_ilp.c
@@ -817,20 +817,6 @@ __isl_give isl_multi_val *isl_union_set_min_multi_union_pw_aff(
 	return isl_union_set_opt_multi_union_pw_aff(uset, 0, obj);
 }
 
-/* Return a list of maxima over the points in "uset"
- * for each of the expressions in "obj".
- *
- * An element in the list is infinity or negative infinity if the optimal
- * value of the corresponding expression is unbounded and
- * NaN if the intersection of "uset" with the domain of the expression
- * is empty.
- */
-__isl_give isl_multi_val *isl_union_set_max_multi_union_pw_aff(
-	__isl_keep isl_union_set *uset, __isl_keep isl_multi_union_pw_aff *obj)
-{
-	return isl_union_set_opt_multi_union_pw_aff(uset, 1, obj);
-}
-
 /* Return the maximal value attained by the given set dimension,
  * independently of the parameter values and of any other dimensions.
  *


### PR DESCRIPTION
This reverts commit 9cc05132b009d6dba51d3fd596f04369d78f23ef.

The function isl_union_set_max_multi_union_pw_aff introduced by
that commit is not currently used by TC and a different variant
will be added to mainline isl, which would result in conflicts.