### PR TITLE
fix miss merge

### DIFF
--- a/isl_test_cpp.cc
+++ b/isl_test_cpp.cc
@@ -132,10 +132,10 @@ static void test_exception(isl::ctx ctx)
 	try {
 		auto umap = isl::union_map::from(mupa);
 	} catch (const isl::exception &error) {
-		assert(strstr(error.what(), "cannot determine domain"));
+		assert(strstr(error.what(), "without explicit domain"));
 		copy = error;
 	}
-	assert(strstr(copy.what(), "cannot determine domain"));
+	assert(strstr(copy.what(), "without explicit domain"));
 }
 
 /* Test basic schedule tree functionality.


### PR DESCRIPTION
Combining the commits "introduce cpp bindings generation (with exceptions)"
and "keep track of domain in 0D isl_multi_pw_aff and isl_multi_union_pw_aff"
requires some adjustment of the expected error message.
This went unnoticed because the C++ bindings test do not get
run in this repository.