### PR TITLE
add schedule_nonneg_var_coefficient

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -423,6 +423,8 @@ EXTRA_DIST = \
 	LICENSE \
 	isl_config_post.h \
 	basis_reduction_templ.c \
+	bmap_to_sys_inl.c \
+	bmap_from_sys_inl.c \
 	bset_to_bmap.c \
 	bset_from_bmap.c \
 	extract_key.c \
@@ -478,6 +480,7 @@ EXTRA_DIST = \
 	set_to_map.c \
 	set_from_map.c \
 	set_list_from_map_list_inl.c \
+	isl_system_bound_templ.c \
 	isl_tab_lexopt_templ.c \
 	uset_to_umap.c \
 	uset_from_umap.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -198,6 +198,10 @@ libisl_la_SOURCES = \
 	isl_seq.c \
 	isl_seq.h \
 	isl_stride.c \
+	isl_system.c \
+	isl_system.h \
+	isl_system_type.h \
+	isl_system_private.h \
 	isl_tab.c \
 	isl_tab.h \
 	isl_tab_pip.c \

--- a/bmap_from_sys_inl.c
+++ b/bmap_from_sys_inl.c
@@ -1,0 +1,9 @@
+#include <isl_system_type.h>
+#include <isl/map_type.h>
+
+/* Return the basic map that was treated as a pure system of linear constraints.
+ */
+static __isl_give isl_basic_map *bmap_from_sys(__isl_take isl_system *sys)
+{
+	return (isl_basic_map *) sys;
+}

--- a/bmap_to_sys_inl.c
+++ b/bmap_to_sys_inl.c
@@ -1,0 +1,9 @@
+#include <isl_system_type.h>
+#include <isl/map_type.h>
+
+/* Treat "bmap" as a pure system of linear constraints.
+ */
+static __isl_give isl_system *bmap_to_sys(__isl_take isl_basic_map *bmap)
+{
+	return (isl_system *) bmap;
+}

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -10146,6 +10146,14 @@ L</"Schedule Trees">.
 =head3 Options
 
 	#include <isl/schedule.h>
+	isl_stat isl_options_set_schedule_max_var_coefficient(
+		isl_ctx *ctx, int val);
+	int isl_options_get_schedule_max_var_coefficient(
+		isl_ctx *ctx);
+	isl_stat isl_options_set_schedule_max_param_coefficient(
+		isl_ctx *ctx, int val);
+	int isl_options_get_schedule_max_param_coefficient(
+		isl_ctx *ctx);
 	isl_stat isl_options_set_schedule_max_coefficient(
 		isl_ctx *ctx, int val);
 	int isl_options_get_schedule_max_coefficient(
@@ -10201,13 +10209,13 @@ L</"Schedule Trees">.
 
 =over
 
-=item * schedule_max_coefficient
+=item * schedule_max_var_coefficient
 
-This option enforces that the coefficients for variable and parameter
+This option enforces that the coefficients for variable
 dimensions in the calculated schedule are not larger than the specified value.
 This option can significantly increase the speed of the scheduling calculation
 and may also prevent fusing of unrelated dimensions. A value of -1 means that
-this option does not introduce bounds on the variable or parameter
+this option does not introduce bounds on the variable
 coefficients.
 If the C<schedule_whole_component> option is turned off,
 then the bound gets applied to both the schedules
@@ -10215,6 +10223,25 @@ of the individual strongly connected components and their combinations.
 The coefficients can accumulate during this process and
 may therefore end up being (much) larger than the bound.
 This option has no effect on the Feautrier style scheduler.
+
+=item * schedule_max_param_coefficient
+
+This option enforces that the coefficients for parameter
+dimensions in the calculated schedule are not larger than the specified value.
+A value of -1 means that
+this option does not introduce bounds on the parameter
+coefficients.
+If the C<schedule_whole_component> option is turned off,
+then the bound gets applied to both the schedules
+of the individual strongly connected components and their combinations.
+The coefficients can accumulate during this process and
+may therefore end up being (much) larger than the bound.
+This option has no effect on the Feautrier style scheduler.
+
+=item * schedule_max_coefficient
+
+Setting this option sets both the C<schedule_max_var_coefficient> and
+the C<schedule_max_param_coefficient> option to the (same) specified value.
 
 =item * schedule_unit_max_var_coefficient_sum
 

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -1217,6 +1217,13 @@ Additional parameters can be added to a space using the following function.
 If a parameter with the given identifier already appears in the space,
 then it is not added again.
 
+Conversely, all parameters can be removed from a space
+using the following function.
+
+	#include <isl/space.h>
+	__isl_give isl_space *isl_space_drop_all_params(
+		__isl_take isl_space *space);
+
 The presence of a parameter in a space can be checked using
 the following function.
 

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -10209,6 +10209,7 @@ This option can significantly increase the speed of the scheduling calculation
 and may also prevent fusing of unrelated dimensions. A value of -1 means that
 this option does not introduce bounds on the variable or parameter
 coefficients.
+This option has no effect on the Feautrier style scheduler.
 
 =item * schedule_unit_max_var_coefficient_sum
 

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -10153,6 +10153,10 @@ L</"Schedule Trees">.
 =head3 Options
 
 	#include <isl/schedule.h>
+	isl_stat isl_options_set_schedule_nonneg_var_coefficient(
+		isl_ctx *ctx, int val);
+	int isl_options_get_schedule_nonneg_var_coefficient(
+		isl_ctx *ctx);
 	isl_stat isl_options_set_schedule_max_var_coefficient(
 		isl_ctx *ctx, int val);
 	int isl_options_get_schedule_max_var_coefficient(
@@ -10215,6 +10219,12 @@ L</"Schedule Trees">.
 		isl_ctx *ctx);
 
 =over
+
+=item * schedule_nonneg_var_coefficient
+
+If this options is set, then all schedule coefficients of the variables
+will be non-negative.
+This option has no effect on the Feautrier style scheduler.
 
 =item * schedule_max_var_coefficient
 

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -10209,6 +10209,11 @@ This option can significantly increase the speed of the scheduling calculation
 and may also prevent fusing of unrelated dimensions. A value of -1 means that
 this option does not introduce bounds on the variable or parameter
 coefficients.
+If the C<schedule_whole_component> option is turned off,
+then the bound gets applied to both the schedules
+of the individual strongly connected components and their combinations.
+The coefficients can accumulate during this process and
+may therefore end up being (much) larger than the bound.
 This option has no effect on the Feautrier style scheduler.
 
 =item * schedule_unit_max_var_coefficient_sum

--- a/doc/user.pod
+++ b/doc/user.pod
@@ -10224,11 +10224,6 @@ This option can significantly increase the speed of the scheduling calculation
 and may also prevent fusing of unrelated dimensions. A value of -1 means that
 this option does not introduce bounds on the variable
 coefficients.
-If the C<schedule_whole_component> option is turned off,
-then the bound gets applied to both the schedules
-of the individual strongly connected components and their combinations.
-The coefficients can accumulate during this process and
-may therefore end up being (much) larger than the bound.
 This option has no effect on the Feautrier style scheduler.
 
 =item * schedule_max_param_coefficient

--- a/include/isl/arg.h
+++ b/include/isl/arg.h
@@ -192,7 +192,7 @@ struct isl_args {
 	.offset = offsetof(st, f),					\
 	.help_msg = h,							\
 	.flags = fl,							\
-	.u = { .ul = { .default_value = d } }				\
+	.u = { .i = { .default_value = d } }				\
 },
 #define ISL_ARG_INT(st,f,s,l,a,d,h)					\
 	ISL_ARG_INT_F(st,f,s,l,a,d,h,0)

--- a/include/isl/arg.h
+++ b/include/isl/arg.h
@@ -76,6 +76,7 @@ struct isl_arg {
 	} b;
 	struct {
 		int			default_value;
+		int (*set)(void *opt, int val);
 	} i;
 	struct {
 		long		 	default_value;
@@ -184,7 +185,7 @@ struct isl_args {
 	_ISL_ARG_BOOL_F(-1,s,l,setter,0,h,fl)
 #define ISL_ARG_PHANTOM_BOOL(s,l,setter,h)				\
 	ISL_ARG_PHANTOM_BOOL_F(s,l,setter,h,0)
-#define ISL_ARG_INT_F(st,f,s,l,a,d,h,fl)	{			\
+#define ISL_ARG_USER_INT_F(st,f,s,l,a,setter,d,h,fl)	{		\
 	.type = isl_arg_int,						\
 	.short_name = s,						\
 	.long_name = l,							\
@@ -192,10 +193,14 @@ struct isl_args {
 	.offset = offsetof(st, f),					\
 	.help_msg = h,							\
 	.flags = fl,							\
-	.u = { .i = { .default_value = d } }				\
+	.u = { .i = { .default_value = d, .set = setter } }		\
 },
+#define ISL_ARG_INT_F(st,f,s,l,a,d,h,fl)				\
+	ISL_ARG_USER_INT_F(st,f,s,l,a,NULL,d,h,fl)
 #define ISL_ARG_INT(st,f,s,l,a,d,h)					\
 	ISL_ARG_INT_F(st,f,s,l,a,d,h,0)
+#define ISL_ARG_USER_INT(st,f,s,l,a,setter,d,h)				\
+	ISL_ARG_USER_INT_F(st,f,s,l,a,setter,d,h,0)
 #define ISL_ARG_LONG(st,f,s,lo,d,h)	{				\
 	.type = isl_arg_long,						\
 	.short_name = s,						\

--- a/include/isl/schedule.h
+++ b/include/isl/schedule.h
@@ -18,6 +18,12 @@ extern "C" {
 struct __isl_export isl_schedule_constraints;
 typedef struct isl_schedule_constraints isl_schedule_constraints;
 
+isl_stat isl_options_set_schedule_max_var_coefficient(isl_ctx *ctx, int val);
+int isl_options_get_schedule_max_var_coefficient(isl_ctx *ctx);
+
+isl_stat isl_options_set_schedule_max_param_coefficient(isl_ctx *ctx, int val);
+int isl_options_get_schedule_max_param_coefficient(isl_ctx *ctx);
+
 isl_stat isl_options_set_schedule_max_coefficient(isl_ctx *ctx, int val);
 int isl_options_get_schedule_max_coefficient(isl_ctx *ctx);
 

--- a/include/isl/schedule.h
+++ b/include/isl/schedule.h
@@ -18,6 +18,9 @@ extern "C" {
 struct __isl_export isl_schedule_constraints;
 typedef struct isl_schedule_constraints isl_schedule_constraints;
 
+isl_stat isl_options_set_schedule_nonneg_var_coefficient(isl_ctx *ctx, int val);
+int isl_options_get_schedule_nonneg_var_coefficient(isl_ctx *ctx);
+
 isl_stat isl_options_set_schedule_max_var_coefficient(isl_ctx *ctx, int val);
 int isl_options_get_schedule_max_var_coefficient(isl_ctx *ctx);
 

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -142,6 +142,7 @@ __isl_give isl_space *isl_space_drop_inputs(__isl_take isl_space *dim,
 ISL_DEPRECATED
 __isl_give isl_space *isl_space_drop_outputs(__isl_take isl_space *dim,
 		unsigned first, unsigned n);
+__isl_give isl_space *isl_space_drop_all_params(__isl_take isl_space *space);
 __isl_export
 __isl_give isl_space *isl_space_domain(__isl_take isl_space *space);
 __isl_export

--- a/isl_arg.c
+++ b/isl_arg.c
@@ -1012,13 +1012,16 @@ static int parse_str_list_option(struct isl_arg *decl, char **arg,
 }
 
 /* Set the option described by "decl" inside the options structure
- * at "opt" to "val".
+ * at "opt" to "val" and call the user-specified setter (if there
+ * is one).
  */
 static void set_int_option(struct isl_arg *decl, void *opt, int val)
 {
 	int *p = (int *)(((char *)opt) + decl->offset);
 
 	*p = val;
+	if (decl->u.i.set)
+		decl->u.i.set(opt, val);
 }
 
 static int parse_int_option(struct isl_arg *decl, char **arg,

--- a/isl_arg.c
+++ b/isl_arg.c
@@ -1011,27 +1011,36 @@ static int parse_str_list_option(struct isl_arg *decl, char **arg,
 	return 0;
 }
 
+/* Set the option described by "decl" inside the options structure
+ * at "opt" to "val".
+ */
+static void set_int_option(struct isl_arg *decl, void *opt, int val)
+{
+	int *p = (int *)(((char *)opt) + decl->offset);
+
+	*p = val;
+}
+
 static int parse_int_option(struct isl_arg *decl, char **arg,
 	struct isl_prefixes *prefixes, void *opt)
 {
 	int has_argument;
 	const char *val;
 	char *endptr;
-	int *p = (int *)(((char *)opt) + decl->offset);
 
 	val = skip_name(decl, arg[0], prefixes, 0, &has_argument);
 	if (!val)
 		return 0;
 
 	if (has_argument) {
-		*p = atoi(val);
+		set_int_option(decl, opt, atoi(val));
 		return 1;
 	}
 
 	if (arg[1]) {
 		int i = strtol(arg[1], &endptr, 0);
 		if (*endptr == '\0') {
-			*p = i;
+			set_int_option(decl, opt, i);
 			return 2;
 		}
 	}

--- a/isl_dim_map.c
+++ b/isl_dim_map.c
@@ -110,7 +110,7 @@ void isl_dim_map_dump(struct isl_dim_map *dim_map)
 }
 
 static void copy_constraint_dim_map(isl_int *dst, isl_int *src,
-					struct isl_dim_map *dim_map)
+	__isl_keep isl_dim_map *dim_map)
 {
 	int i;
 
@@ -125,7 +125,7 @@ static void copy_constraint_dim_map(isl_int *dst, isl_int *src,
 }
 
 static void copy_div_dim_map(isl_int *dst, isl_int *src,
-					struct isl_dim_map *dim_map)
+	__isl_keep isl_dim_map *dim_map)
 {
 	isl_int_set(dst[0], src[0]);
 	copy_constraint_dim_map(dst+1, src+1, dim_map);

--- a/isl_dim_map.h
+++ b/isl_dim_map.h
@@ -20,6 +20,8 @@ void isl_dim_map_dim(__isl_keep isl_dim_map *dim_map, __isl_keep isl_space *dim,
 	enum isl_dim_type type, unsigned dst_pos);
 void isl_dim_map_div(__isl_keep isl_dim_map *dim_map,
 	__isl_keep isl_basic_map *bmap, unsigned dst_pos);
+void isl_dim_map_cpy_lin(__isl_keep isl_dim_map *dim_map,
+	isl_int *dst, isl_int *src);
 __isl_give isl_basic_set *isl_basic_set_add_constraints_dim_map(
 	__isl_take isl_basic_set *dst, __isl_take isl_basic_set *src,
 	__isl_take isl_dim_map *dim_map);

--- a/isl_map.c
+++ b/isl_map.c
@@ -8383,29 +8383,22 @@ __isl_give isl_map *isl_set_identity(__isl_take isl_set *set)
 __isl_give isl_basic_set *isl_basic_set_positive_orthant(
 	__isl_take isl_space *space)
 {
-	int i;
 	unsigned nparam;
 	unsigned dim;
+	unsigned total;
+	isl_ctx *ctx;
+	isl_system *sys;
 	struct isl_basic_set *bset;
 
 	if (!space)
 		return NULL;
 	nparam = space->nparam;
 	dim = space->n_out;
-	bset = isl_basic_set_alloc_space(space, 0, 0, dim);
-	if (!bset)
-		return NULL;
-	for (i = 0; i < dim; ++i) {
-		int k = isl_basic_set_alloc_inequality(bset);
-		if (k < 0)
-			goto error;
-		isl_seq_clr(bset->ineq[k], 1 + isl_basic_set_total_dim(bset));
-		isl_int_set_si(bset->ineq[k][1 + nparam + i], 1);
-	}
+	total = isl_space_dim(space, isl_dim_all);
+	ctx = isl_space_get_ctx(space);
+	sys = isl_system_nonneg(ctx, total, nparam, dim);
+	bset = isl_basic_set_from_space_and_system(space, sys);
 	return bset;
-error:
-	isl_basic_set_free(bset);
-	return NULL;
 }
 
 /* Construct the half-space x_pos >= 0.
@@ -13775,6 +13768,19 @@ __isl_give isl_basic_set *isl_basic_set_transform_dims(
 	__isl_take isl_mat *trans)
 {
 	return isl_basic_map_transform_dims(bset, type, first, trans);
+}
+
+/* Construct a basic set from a system of constraints
+ * (without local variables) within the given space.
+ */
+__isl_give isl_basic_set *isl_basic_set_from_space_and_system(
+	__isl_take isl_space *space, __isl_take isl_system *sys)
+{
+	isl_basic_set *bset;
+
+	bset = isl_basic_set_from_system(sys);
+	bset = isl_basic_set_reset_space(bset, space);
+	return bset;
 }
 
 /* Construct a basic set from a system of constraints,

--- a/isl_map.c
+++ b/isl_map.c
@@ -13776,3 +13776,11 @@ __isl_give isl_basic_set *isl_basic_set_transform_dims(
 {
 	return isl_basic_map_transform_dims(bset, type, first, trans);
 }
+
+/* Construct a basic set from a system of constraints,
+ * without local variables and without specifying a space.
+ */
+__isl_give isl_basic_set *isl_basic_set_from_system(__isl_take isl_system *sys)
+{
+	return bset_from_bmap(bmap_from_sys(sys));
+}

--- a/isl_map_private.h
+++ b/isl_map_private.h
@@ -22,6 +22,7 @@
 #include <isl/vec.h>
 #include <isl/hash.h>
 #include <isl_blk.h>
+#include <isl_system_type.h>
 
 /* A "basic map" is a relation between two sets of variables,
  * called the "in" and "out" variables.
@@ -462,6 +463,8 @@ isl_bool isl_basic_map_divs_known(__isl_keep isl_basic_map *bmap);
 isl_bool isl_map_divs_known(__isl_keep isl_map *map);
 __isl_give isl_mat *isl_basic_set_get_divs(__isl_keep isl_basic_set *bset);
 __isl_give isl_mat *isl_basic_map_get_divs(__isl_keep isl_basic_map *bmap);
+
+__isl_give isl_basic_set *isl_basic_set_from_system(__isl_take isl_system *sys);
 
 __isl_give isl_map *isl_map_inline_foreach_basic_map(__isl_take isl_map *map,
 	__isl_give isl_basic_map *(*fn)(__isl_take isl_basic_map *bmap));

--- a/isl_map_private.h
+++ b/isl_map_private.h
@@ -447,6 +447,9 @@ __isl_give isl_basic_set *isl_basic_set_expand_divs(
 __isl_give isl_basic_map *isl_basic_map_expand_divs(
 	__isl_take isl_basic_set *bmap, __isl_take isl_mat *div, int *exp);
 
+__isl_give isl_basic_set *isl_basic_set_from_space_and_system(
+	__isl_take isl_space *space, __isl_take isl_system *sys);
+
 int isl_basic_set_n_equality(__isl_keep isl_basic_set *bset);
 int isl_basic_map_n_equality(__isl_keep isl_basic_map *bmap);
 int isl_basic_set_n_inequality(__isl_keep isl_basic_set *bset);

--- a/isl_options.c
+++ b/isl_options.c
@@ -149,6 +149,10 @@ ISL_ARG_CHOICE(struct isl_options, convex, 0, "convex-hull", \
 	convex,	ISL_CONVEX_HULL_WRAP, "convex hull algorithm to use")
 ISL_ARG_BOOL(struct isl_options, coalesce_bounded_wrapping, 0,
 	"coalesce-bounded-wrapping", 1, "bound wrapping during coalescing")
+ISL_ARG_BOOL(struct isl_options, schedule_nonneg_var_coefficient, 0,
+	"schedule-nonneg-var-coefficient", 0, "Only consider schedules "
+	"where the coefficients of the variable dimensions "
+        "are non-negative.")
 ISL_ARG_INT(struct isl_options, schedule_max_var_coefficient, 0,
 	"schedule-max-var-coefficient", "limit", -1, "Only consider schedules "
 	"where the coefficients of the variable dimensions "
@@ -274,6 +278,11 @@ ISL_CTX_SET_BOOL_DEF(isl_options, struct isl_options, isl_options_args,
 	gbr_only_first)
 ISL_CTX_GET_BOOL_DEF(isl_options, struct isl_options, isl_options_args,
 	gbr_only_first)
+
+ISL_CTX_SET_INT_DEF(isl_options, struct isl_options, isl_options_args,
+	schedule_nonneg_var_coefficient)
+ISL_CTX_GET_INT_DEF(isl_options, struct isl_options, isl_options_args,
+	schedule_nonneg_var_coefficient)
 
 /* Set the schedule_max_coefficient option to "val" and
  * call set_max_coefficient to set schedule_max_var_coefficient and

--- a/isl_options_private.h
+++ b/isl_options_private.h
@@ -36,6 +36,8 @@ struct isl_options {
 	int			coalesce_bounded_wrapping;
 
 	int			schedule_max_coefficient;
+	int			schedule_max_var_coefficient;
+	int			schedule_max_param_coefficient;
 	int			schedule_unit_max_var_coefficient_sum;
 	int			schedule_max_constant_term;
 	int			schedule_parametric;

--- a/isl_options_private.h
+++ b/isl_options_private.h
@@ -35,6 +35,7 @@ struct isl_options {
 
 	int			coalesce_bounded_wrapping;
 
+	int			schedule_nonneg_var_coefficient;
 	int			schedule_max_coefficient;
 	int			schedule_max_var_coefficient;
 	int			schedule_max_param_coefficient;

--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -126,7 +126,7 @@ error:
  * "sizes" contains the sizes of the (compressed) instance set
  * in each direction.  If there is no fixed size in a given direction,
  * then the corresponding size value is set to infinity.
- * If the schedule_treat_coalescing option or the schedule_max_coefficient
+ * If the schedule_treat_coalescing option or the schedule_max_var_coefficient
  * option is set, then "max" contains the maximal values for
  * schedule coefficients of the (compressed) variables.  If no bound
  * needs to be imposed on a particular variable, then the corresponding
@@ -868,14 +868,14 @@ static isl_bool has_any_defining_equality(__isl_keep isl_basic_set *bset)
 	return isl_bool_false;
 }
 
-/* Set the entries of node->max to the value of the schedule_max_coefficient
+/* Set the entries of node->max to the value of the schedule_max_var_coefficient
  * option, if set.
  */
 static isl_stat set_max_coefficient(isl_ctx *ctx, struct isl_sched_node *node)
 {
 	int max;
 
-	max = isl_options_get_schedule_max_coefficient(ctx);
+	max = isl_options_get_schedule_max_var_coefficient(ctx);
 	if (max == -1)
 		return isl_stat_ok;
 
@@ -887,13 +887,14 @@ static isl_stat set_max_coefficient(isl_ctx *ctx, struct isl_sched_node *node)
 	return isl_stat_ok;
 }
 
-/* Set the entries of node->max to the minimum of the schedule_max_coefficient
+/* Set the entries of node->max to the minimum of
+ * the schedule_max_var_coefficient
  * option (if set) and half of the minimum of the sizes in the other
  * dimensions.  Round up when computing the half such that
  * if the minimum of the sizes is one, half of the size is taken to be one
  * rather than zero.
  * If the global minimum is unbounded (i.e., if both
- * the schedule_max_coefficient is not set and the sizes in the other
+ * the schedule_max_var_coefficient is not set and the sizes in the other
  * dimensions are unbounded), then store a negative value.
  * If the schedule coefficient is close to the size of the instance set
  * in another dimension, then the schedule may represent a loop
@@ -909,7 +910,7 @@ static isl_stat compute_max_coefficient(isl_ctx *ctx,
 	int i, j;
 	isl_vec *v;
 
-	max = isl_options_get_schedule_max_coefficient(ctx);
+	max = isl_options_get_schedule_max_var_coefficient(ctx);
 	v = isl_vec_alloc(ctx, node->nvar);
 	if (!v)
 		return isl_stat_error;
@@ -991,7 +992,7 @@ static __isl_give isl_val *compute_size(__isl_take isl_set *set, int dim)
  *
  * The sizes are needed when the schedule_treat_coalescing option is set.
  * The bounds are needed when the schedule_treat_coalescing option or
- * the schedule_max_coefficient option is set.
+ * the schedule_max_var_coefficient option is set.
  *
  * If the schedule_treat_coalescing option is not set, then at most
  * the bounds need to be set and this is done in set_max_coefficient.
@@ -1002,7 +1003,7 @@ static __isl_give isl_val *compute_size(__isl_take isl_set *set, int dim)
  * that are valid for the individual disjuncts, but not for
  * the domain as a whole.
  * Finally, set the bounds on the coefficients based on the sizes
- * and the schedule_max_coefficient option in compute_max_coefficient.
+ * and the schedule_max_var_coefficient option in compute_max_coefficient.
  */
 static isl_stat compute_sizes_and_max(isl_ctx *ctx, struct isl_sched_node *node,
 	__isl_take isl_set *set)
@@ -2810,7 +2811,7 @@ static isl_stat add_bound_constant_constraints(isl_ctx *ctx,
  * accordingly.
  *
  * In practice, add_bound_param_coefficient_constraints only adds inequalities.
- * A negative value for the "schedule_max_coefficient" option
+ * A negative value for the "schedule_max_param_coefficient" option
  * means that no bound needs to be imposed.
  */
 static isl_stat count_bound_param_coefficient_constraints(isl_ctx *ctx,
@@ -2818,7 +2819,7 @@ static isl_stat count_bound_param_coefficient_constraints(isl_ctx *ctx,
 {
 	int i;
 
-	if (isl_options_get_schedule_max_coefficient(ctx) < 0)
+	if (isl_options_get_schedule_max_param_coefficient(ctx) < 0)
 		return isl_stat_ok;
 
 	for (i = 0; i < graph->n; ++i)
@@ -2838,7 +2839,7 @@ static isl_stat count_bound_var_coefficient_constraints(isl_ctx *ctx,
 {
 	int i;
 
-	if (isl_options_get_schedule_max_coefficient(ctx) == -1 &&
+	if (isl_options_get_schedule_max_var_coefficient(ctx) == -1 &&
 	    !isl_options_get_schedule_treat_coalescing(ctx))
 		return isl_stat_ok;
 
@@ -2967,7 +2968,7 @@ error:
  * coefficients of the schedule.
  *
  * The maximal value of the coefficients is defined by the option
- * 'schedule_max_coefficient'.
+ * 'schedule_max_param_coefficient'.
  * A negative value means that no bound needs to be imposed.
  */
 static isl_stat add_bound_param_coefficient_constraints(isl_ctx *ctx,
@@ -2976,7 +2977,7 @@ static isl_stat add_bound_param_coefficient_constraints(isl_ctx *ctx,
 	int i;
 	int max;
 
-	max = isl_options_get_schedule_max_coefficient(ctx);
+	max = isl_options_get_schedule_max_param_coefficient(ctx);
 
 	if (max < 0)
 		return isl_stat_ok;
@@ -2996,7 +2997,7 @@ static isl_stat add_bound_param_coefficient_constraints(isl_ctx *ctx,
  * coefficients of the schedule.
  *
  * The maximal value of the coefficients is defined by the entries in node->max.
- * These entries are only set if either the schedule_max_coefficient
+ * These entries are only set if either the schedule_max_var_coefficient
  * option or the schedule_treat_coalescing option is set.
  */
 static isl_stat add_bound_var_coefficient_constraints(isl_ctx *ctx,
@@ -3005,7 +3006,7 @@ static isl_stat add_bound_var_coefficient_constraints(isl_ctx *ctx,
 	int i;
 	int max;
 
-	max = isl_options_get_schedule_max_coefficient(ctx);
+	max = isl_options_get_schedule_max_var_coefficient(ctx);
 
 	if (max == -1 && !isl_options_get_schedule_treat_coalescing(ctx))
 		return isl_stat_ok;

--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -2834,6 +2834,18 @@ static isl_stat count_bound_param_coefficient_constraints(isl_ctx *ctx,
 	return isl_stat_ok;
 }
 
+/* Return the maximal number of constraints added by
+ * node_add_var_coefficient_constraints for "node".
+ *
+ * For each entry in node->max that is not negative,
+ * two constraints get added.
+ */
+static int node_max_bound_var_coefficient_constraints(
+	struct isl_sched_node *node)
+{
+	return 2 * node->nvar;
+}
+
 /* Count the number of constraints that will be added by
  * add_bound_var_coefficient_constraints and increment *n_eq and *n_ineq
  * accordingly.
@@ -2849,8 +2861,11 @@ static isl_stat count_bound_var_coefficient_constraints(isl_ctx *ctx,
 	    !isl_options_get_schedule_treat_coalescing(ctx))
 		return isl_stat_ok;
 
-	for (i = 0; i < graph->n; ++i)
-		*n_ineq += 2 * graph->node[i].nvar;
+	for (i = 0; i < graph->n; ++i) {
+		struct isl_sched_node *node = &graph->node[i];
+
+		*n_ineq += node_max_bound_var_coefficient_constraints(node);
+	}
 
 	return isl_stat_ok;
 }

--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -2095,14 +2095,23 @@ static int node_var_coef_offset(struct isl_sched_node *node)
 }
 
 /* Return the position of the pair of variables encoding
- * coefficient "i" of "node".
+ * coefficient "i" of "node", within the sequence of coefficients
+ * of the variables of "node".
  *
  * The order of these variable pairs is the opposite of
  * that of the coefficients, with 2 variables per coefficient.
  */
+static int node_local_var_coef_pos(struct isl_sched_node *node, int i)
+{
+	return 2 * (node->nvar - 1 - i);
+}
+
+/* Return the position of the pair of variables encoding
+ * coefficient "i" of "node".
+ */
 static int node_var_coef_pos(struct isl_sched_node *node, int i)
 {
-	return node_var_coef_offset(node) + 2 * (node->nvar - 1 - i);
+	return node_var_coef_offset(node) + node_local_var_coef_pos(node, i);
 }
 
 /* Construct an isl_dim_map for mapping constraints on coefficients

--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -2811,19 +2811,19 @@ static isl_stat add_bound_constant_constraints(isl_ctx *ctx,
  *
  * In practice, add_bound_coefficient_constraints only adds inequalities.
  */
-static int count_bound_coefficient_constraints(isl_ctx *ctx,
+static isl_stat count_bound_coefficient_constraints(isl_ctx *ctx,
 	struct isl_sched_graph *graph, int *n_eq, int *n_ineq)
 {
 	int i;
 
 	if (isl_options_get_schedule_max_coefficient(ctx) == -1 &&
 	    !isl_options_get_schedule_treat_coalescing(ctx))
-		return 0;
+		return isl_stat_ok;
 
 	for (i = 0; i < graph->n; ++i)
 		*n_ineq += graph->node[i].nparam + 2 * graph->node[i].nvar;
 
-	return 0;
+	return isl_stat_ok;
 }
 
 /* Add constraints to graph->lp that bound the values of

--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -3446,8 +3446,6 @@ static __isl_give isl_vec *solve_lp(isl_ctx *ctx, struct isl_sched_graph *graph)
  * Each schedule coefficient c_i_x is represented as the difference
  * between two non-negative variables c_i_x^+ - c_i_x^-.
  * The c_i_x^- appear before their c_i_x^+ counterpart.
- * Furthermore, the order of these pairs is the opposite of that
- * of the corresponding coefficients.
  *
  * Return c_i_x = c_i_x^+ - c_i_x^-
  */
@@ -3464,10 +3462,10 @@ static __isl_give isl_vec *extract_var_coef(struct isl_sched_node *node,
 	if (!csol)
 		return NULL;
 
-	pos = 1 + node_var_coef_offset(node);
-	for (i = 0; i < node->nvar; ++i)
-		isl_int_sub(csol->el[node->nvar - 1 - i],
-			    sol->el[pos + 2 * i + 1], sol->el[pos + 2 * i]);
+	for (i = 0; i < node->nvar; ++i) {
+		pos = 1 + node_var_coef_pos(node, i);
+		isl_int_sub(csol->el[i], sol->el[pos + 1], sol->el[pos]);
+	}
 
 	return csol;
 }

--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -2055,6 +2055,18 @@ static int coef_var_offset(__isl_keep isl_basic_set *coef)
 	return offset;
 }
 
+/* Return the number of variables needed for "node" within the (I)LP.
+ *
+ * Within each node, the coefficients have the following order:
+ *	- positive and negative parts of c_i_x
+ *	- c_i_n (if parametric)
+ *	- c_i_0
+ */
+static int node_coef_size(struct isl_sched_node *node)
+{
+	return 2 * node->nvar + node->nparam + 1;
+}
+
 /* Return the offset of the coefficient of the constant term of "node"
  * within the (I)LP.
  *
@@ -3264,7 +3276,7 @@ static isl_stat setup_lp(isl_ctx *ctx, struct isl_sched_graph *graph,
 		if (node_update_vmap(node) < 0)
 			return isl_stat_error;
 		node->start = total;
-		total += 1 + node->nparam + 2 * node->nvar;
+		total += node_coef_size(node);
 	}
 
 	if (count_constraints(graph, &n_eq, &n_ineq, use_coincidence) < 0)
@@ -4742,7 +4754,7 @@ static isl_stat setup_carry_lp(isl_ctx *ctx, struct isl_sched_graph *graph,
 	for (i = 0; i < graph->n; ++i) {
 		struct isl_sched_node *node = &graph->node[graph->sorted[i]];
 		node->start = total;
-		total += 1 + node->nparam + 2 * node->nvar;
+		total += node_coef_size(node);
 	}
 
 	if (count_all_constraints(intra, inter, &n_eq, &n_ineq) < 0)

--- a/isl_space.c
+++ b/isl_space.c
@@ -1889,6 +1889,16 @@ __isl_give isl_space *isl_space_drop_outputs(__isl_take isl_space *dim,
 	return isl_space_drop_dims(dim, isl_dim_out, first, n);
 }
 
+/* Remove all parameters from "space".
+ */
+__isl_give isl_space *isl_space_drop_all_params(__isl_take isl_space *space)
+{
+	unsigned nparam;
+
+	nparam = isl_space_dim(space, isl_dim_param);
+	return isl_space_drop_dims(space, isl_dim_param, 0, nparam);
+}
+
 __isl_give isl_space *isl_space_domain(__isl_take isl_space *space)
 {
 	if (!space)

--- a/isl_system.c
+++ b/isl_system.c
@@ -1,9 +1,12 @@
 /*
+ * Copyright 2009      Katholieke Universiteit Leuven
  * Copyright 2016      Sven Verdoolaege
  *
  * Use of this software is governed by the MIT license
  *
- * Written by Sven Verdoolaege
+ * Written by Sven Verdoolaege,
+ * K.U.Leuven, Departement Computerwetenschappen, Celestijnenlaan 200A,
+ * B-3001 Leuven, Belgium
  */
 
 /* An isl_system is a system of constraints.
@@ -140,3 +143,18 @@ static isl_stat isl_system_check_range(__isl_keep isl_system *sys,
 #define INT_NEG(r,i)	isl_int_neg(r,i)
 
 #include "isl_system_bound_templ.c"
+
+/* Create an isl_system of dimension "n_var", where the "n" variables
+ * starting at position "pos" are non-negative.
+ */
+__isl_give isl_system *isl_system_nonneg(isl_ctx *ctx, unsigned n_var,
+	unsigned pos, unsigned n)
+{
+	int i;
+	isl_system *sys;
+
+	sys = isl_system_alloc(ctx, n_var, 0, 0, n);
+	for (i = 0; i < n; ++i)
+		sys = isl_system_lower_bound_si(sys, pos + i, 0);
+	return sys;
+}

--- a/isl_system.c
+++ b/isl_system.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016      Sven Verdoolaege
+ *
+ * Use of this software is governed by the MIT license
+ *
+ * Written by Sven Verdoolaege
+ */
+
+/* An isl_system is a system of constraints.
+ * For now, use an isl_basic_map as the underlying representation,
+ * but ignore the space and the local variables.
+ */
+#define isl_system	isl_basic_map
+
+#include <isl_ctx_private.h>
+#include <isl_int.h>
+#include <isl_seq.h>
+#include <isl_vec_private.h>
+#include <isl_map_private.h>
+#include <isl_system_private.h>
+
+/* Return the dimension of "sys".
+ *
+ * The underlying basic map is expected to only have set dimensions.
+ */
+unsigned isl_system_dim(__isl_keep isl_system *sys)
+{
+	return isl_basic_map_total_dim(sys);
+}
+
+/* Return the isl_ctx to which "sys" belongs.
+ */
+isl_ctx *isl_system_get_ctx(__isl_keep isl_system *sys)
+{
+	return isl_basic_map_get_ctx(sys);
+}
+
+/* Free "sys" and return NULL.
+ */
+__isl_null isl_system *isl_system_free(__isl_take isl_system *sys)
+{
+	return isl_basic_map_free(sys);
+}
+
+/* Create an isl_system of dimension "n_var", with room for "extra"
+ * extra variables, "n_eq" equality constraints and
+ * "n_ineq" inequality constraints.
+ */
+__isl_give isl_system *isl_system_alloc(isl_ctx *ctx,
+	unsigned n_var, unsigned extra, unsigned n_eq, unsigned n_ineq)
+{
+	isl_space *space;
+
+	space = isl_space_set_alloc(ctx, 0, n_var);
+	return isl_basic_map_alloc_space(space, extra, n_ineq, n_ineq);
+}
+
+/* Return a pointer to a new inequality constraint in "sys",
+ * which is assumed to have enough room for this extra constraint.
+ * Return NULL if an error occurs.
+ *
+ * After filling up the constraint, the caller should call
+ * isl_system_finish_inequality.
+ */
+isl_int *isl_system_alloc_inequality(__isl_keep isl_system *sys)
+{
+	int k;
+
+	k = isl_basic_map_alloc_inequality(sys);
+	if (k < 0)
+		return NULL;
+	return sys->ineq[k];
+}
+
+/* Finish adding the inequality constraint "ineq" to "sys".
+ *
+ * This currently does nothing, but in future, it could normalize
+ * the constraint, perform fangcheng (Gaussian elimination) and/or
+ * check whether any sample value is still valid.
+ */
+__isl_give isl_system *isl_system_finish_inequality(__isl_take isl_system *sys,
+	isl_int *ineq)
+{
+	return sys;
+}
+
+/* Return an isl_system that is equal to "sys" and that has only
+ * a single reference.
+ */
+__isl_give isl_system *isl_system_cow(__isl_take isl_system *sys)
+{
+	return isl_basic_map_cow(sys);
+}
+
+/* Return an isl_system that is equal to "sys" and that has room
+ * for at least "n_eq" more equality constraints and
+ * "n_ineq" more inequality constraints.
+ */
+__isl_give isl_system *isl_system_extend_constraints(
+	__isl_take isl_system *sys, unsigned n_eq, unsigned n_ineq)
+{
+	return isl_basic_map_extend_constraints(sys, n_eq, n_ineq);
+}

--- a/isl_system.c
+++ b/isl_system.c
@@ -101,3 +101,42 @@ __isl_give isl_system *isl_system_extend_constraints(
 {
 	return isl_basic_map_extend_constraints(sys, n_eq, n_ineq);
 }
+
+/* Check that there are "n" dimensions starting at "first" in "sys".
+ */
+static isl_stat isl_system_check_range(__isl_keep isl_system *sys,
+	unsigned first, unsigned n)
+{
+	unsigned dim;
+
+	if (!sys)
+		return isl_stat_error;
+	dim = isl_system_dim(sys);
+	if (first + n > dim || first + n < first)
+		isl_die(isl_system_get_ctx(sys), isl_error_invalid,
+			"position or range out of bounds",
+			return isl_stat_error);
+	return isl_stat_ok;
+}
+
+#undef SUFFIX
+#define SUFFIX		_si
+#undef INT
+#define INT		int
+#undef INT_SET
+#define INT_SET(r,i)	isl_int_set_si(r,i)
+#undef INT_NEG
+#define INT_NEG(r,i)	isl_int_set_si(r,-(i))
+
+#include "isl_system_bound_templ.c"
+
+#undef SUFFIX
+#define SUFFIX
+#undef INT
+#define INT		isl_int
+#undef INT_SET
+#define INT_SET(r,i)	isl_int_set(r,i)
+#undef INT_NEG
+#define INT_NEG(r,i)	isl_int_neg(r,i)
+
+#include "isl_system_bound_templ.c"

--- a/isl_system.h
+++ b/isl_system.h
@@ -1,0 +1,9 @@
+#ifndef ISL_SYSTEM_H
+#define ISL_SYSTEM_H
+
+#include <isl_int.h>
+#include <isl_system_type.h>
+
+__isl_null isl_system *isl_system_free(__isl_take isl_system *sys);
+
+#endif

--- a/isl_system.h
+++ b/isl_system.h
@@ -8,7 +8,15 @@ __isl_null isl_system *isl_system_free(__isl_take isl_system *sys);
 
 __isl_give isl_system *isl_system_bound_si(__isl_take isl_system *sys,
 	unsigned pos, int value, int upper);
+__isl_give isl_system *isl_system_lower_bound_si(__isl_take isl_system *sys,
+	unsigned pos, int value);
+__isl_give isl_system *isl_system_upper_bound_si(__isl_take isl_system *sys,
+	unsigned pos, int value);
 __isl_give isl_system *isl_system_bound(__isl_take isl_system *sys,
 	unsigned pos, isl_int value, int upper);
+__isl_give isl_system *isl_system_lower_bound(__isl_take isl_system *sys,
+	unsigned pos, isl_int value);
+__isl_give isl_system *isl_system_upper_bound(__isl_take isl_system *sys,
+	unsigned pos, isl_int value);
 
 #endif

--- a/isl_system.h
+++ b/isl_system.h
@@ -19,4 +19,7 @@ __isl_give isl_system *isl_system_lower_bound(__isl_take isl_system *sys,
 __isl_give isl_system *isl_system_upper_bound(__isl_take isl_system *sys,
 	unsigned pos, isl_int value);
 
+__isl_give isl_system *isl_system_nonneg(isl_ctx *ctx, unsigned n_var,
+	unsigned pos, unsigned n);
+
 #endif

--- a/isl_system.h
+++ b/isl_system.h
@@ -6,4 +6,9 @@
 
 __isl_null isl_system *isl_system_free(__isl_take isl_system *sys);
 
+__isl_give isl_system *isl_system_bound_si(__isl_take isl_system *sys,
+	unsigned pos, int value, int upper);
+__isl_give isl_system *isl_system_bound(__isl_take isl_system *sys,
+	unsigned pos, isl_int value, int upper);
+
 #endif

--- a/isl_system_bound_templ.c
+++ b/isl_system_bound_templ.c
@@ -35,3 +35,19 @@ __isl_give isl_system *SF(isl_system_bound,SUFFIX)(__isl_take isl_system *sys,
 	sys = isl_system_finish_inequality(sys, ineq);
 	return sys;
 }
+
+/* Bound the given variable of "system" from below to "value".
+ */
+__isl_give isl_system *SF(isl_system_lower_bound,SUFFIX)(
+	__isl_take isl_system *sys, unsigned pos, INT value)
+{
+	return SF(isl_system_bound,SUFFIX)(sys, pos, value, 0);
+}
+
+/* Bound the given variable of "system" from above to "value".
+ */
+__isl_give isl_system *SF(isl_system_upper_bound,SUFFIX)(
+	__isl_take isl_system *sys, unsigned pos, INT value)
+{
+	return SF(isl_system_bound,SUFFIX)(sys, pos, value, 1);
+}

--- a/isl_system_bound_templ.c
+++ b/isl_system_bound_templ.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2011      Sven Verdoolaege
+ *
+ * Use of this software is governed by the MIT license
+ *
+ * Written by Sven Verdoolaege
+ */
+
+#define xSF(TYPE,SUFFIX) TYPE ## SUFFIX
+#define SF(TYPE,SUFFIX) xSF(TYPE,SUFFIX)
+
+/* Bound the given variable of "system" from below (or above if "upper"
+ * is set) to "value".
+ */
+__isl_give isl_system *SF(isl_system_bound,SUFFIX)(__isl_take isl_system *sys,
+	unsigned pos, INT value, int upper)
+{
+	isl_int *ineq;
+
+	if (isl_system_check_range(sys, pos, 1) < 0)
+		return isl_system_free(sys);
+	sys = isl_system_cow(sys);
+	sys = isl_system_extend_constraints(sys, 0, 1);
+	ineq = isl_system_alloc_inequality(sys);
+	if (!ineq)
+		return isl_system_free(sys);
+	isl_seq_clr(ineq, 1 + isl_system_dim(sys));
+	if (upper) {
+		isl_int_set_si(ineq[1 + pos], -1);
+		INT_SET(ineq[0], value);
+	} else {
+		isl_int_set_si(ineq[1 + pos], 1);
+		INT_NEG(ineq[0], value);
+	}
+	sys = isl_system_finish_inequality(sys, ineq);
+	return sys;
+}

--- a/isl_system_private.h
+++ b/isl_system_private.h
@@ -1,0 +1,9 @@
+#ifndef ISL_SYSTEM_PRIVATE_H
+#define ISL_SYSTEM_PRIVATE_H
+
+#include <isl_system.h>
+
+__isl_give isl_system *isl_system_alloc(isl_ctx *ctx,
+	unsigned n_var, unsigned extra, unsigned n_eq, unsigned n_ineq);
+
+#endif

--- a/isl_system_type.h
+++ b/isl_system_type.h
@@ -1,0 +1,7 @@
+#ifndef ISL_SYSTEM_TYPE_H
+#define ISL_SYSTEM_TYPE_H
+
+struct isl_system;
+typedef struct isl_system isl_system;
+
+#endif

--- a/isl_union_map.c
+++ b/isl_union_map.c
@@ -658,8 +658,7 @@ __isl_give isl_map *isl_union_map_extract_map(__isl_keep isl_union_map *umap,
 	uint32_t hash;
 	struct isl_hash_table_entry *entry;
 
-	space = isl_space_drop_dims(space, isl_dim_param,
-					0, isl_space_dim(space, isl_dim_param));
+	space = isl_space_drop_all_params(space);
 	space = isl_space_align_params(space, isl_union_map_get_space(umap));
 	if (!umap || !space)
 		goto error;

--- a/schedule_test.sh.in
+++ b/schedule_test.sh.in
@@ -14,8 +14,14 @@ for i in $srcdir/test_inputs/schedule/*.sc; do
 	dir=`dirname $i`
 	ref=$dir/$base.st
 	options=`$GREP 'OPTIONS:' $i | $SED 's/.*://'`
-	(./isl_schedule$EXEEXT $options < $i > $test &&
-	./isl_schedule_cmp$EXEEXT $ref $test && rm $test) || failed=1
+	for o in --schedule-whole-component --no-schedule-whole-component; do
+		./isl_schedule$EXEEXT $o $options < $i > $test &&
+		    ./isl_schedule_cmp$EXEEXT $ref $test && rm $test
+		if [ $? -ne 0 ]; then
+			echo $o $options
+			failed=1
+		fi
+	done
 done
 
 test $failed -eq 0 || exit

--- a/test_inputs/schedule/max_incremental.sc
+++ b/test_inputs/schedule/max_incremental.sc
@@ -1,0 +1,5 @@
+# Check that the generated schedule does not have coefficients
+# greater than 2.
+# OPTIONS: --no-schedule-whole-component --schedule-max-coefficient=2
+domain: [N] -> { A[i] : 0 <= i < 4N; B[i] : 0 <= i < 2N; C[i] : 0 <= i < N }
+proximity: { A[i] -> B[j] : i = 2j; B[i] -> C[j] : i = 2j }

--- a/test_inputs/schedule/max_incremental.st
+++ b/test_inputs/schedule/max_incremental.st
@@ -1,0 +1,17 @@
+domain: "[N] -> { B[i] : 0 <= i < 2N; A[i] : 0 <= i < 4N; C[i] : 0 <= i < N }"
+child:
+  sequence:
+  - filter: "[N] -> { B[i]; C[i] }"
+    child:
+      schedule: "[N] -> [{ B[i] -> [(i)]; C[i] -> [(2i)] }]"
+      permutable: 1
+      coincident: [ 1 ]
+      child:
+        sequence:
+        - filter: "[N] -> { C[i] }"
+        - filter: "[N] -> { B[i] }"
+  - filter: "[N] -> { A[i] }"
+    child:
+      schedule: "[N] -> [{ A[i] -> [(i)] }]"
+      permutable: 1
+      coincident: [ 1 ]

--- a/test_inputs/schedule/max_whole.sc
+++ b/test_inputs/schedule/max_whole.sc
@@ -1,0 +1,5 @@
+# Check that the generated schedule does not have coefficients
+# greater than 2.
+# OPTIONS: --schedule-whole-component --schedule-max-var-coefficient=2
+domain: [N] -> { A[i] : 0 <= i < 4N; B[i] : 0 <= i < 2N; C[i] : 0 <= i < N }
+proximity: { A[i] -> B[j] : i = 2j; B[i] -> C[j] : i = 2j }

--- a/test_inputs/schedule/max_whole.st
+++ b/test_inputs/schedule/max_whole.st
@@ -1,0 +1,18 @@
+domain: "[N] -> { B[i] : 0 <= i < 2N; A[i] : 0 <= i < 4N; C[i] : 0 <= i < N }"
+child:
+  sequence:
+  - filter: "[N] -> { C[i] }"
+    child:
+      schedule: "[N] -> [{ C[i] -> [(i)] }]"
+      permutable: 1
+      coincident: [ 1 ]
+  - filter: "[N] -> { A[i] }"
+    child:
+      schedule: "[N] -> [{ A[i] -> [(i)] }]"
+      permutable: 1
+      coincident: [ 1 ]
+  - filter: "[N] -> { B[i] }"
+    child:
+      schedule: "[N] -> [{ B[i] -> [(i)] }]"
+      permutable: 1
+      coincident: [ 1 ]

--- a/test_inputs/schedule/nomax.sc
+++ b/test_inputs/schedule/nomax.sc
@@ -1,0 +1,5 @@
+# Check that a schedule with a coefficient of 4 can be generated
+# when the maximal size of the coefficients is set to 4.
+# OPTIONS: --schedule-max-var-coefficient=4
+domain: [N] -> { A[i] : 0 <= i < 4N; B[i] : 0 <= i < 2N; C[i] : 0 <= i < N }
+proximity: { A[i] -> B[j] : i = 2j; B[i] -> C[j] : i = 2j }

--- a/test_inputs/schedule/nomax.st
+++ b/test_inputs/schedule/nomax.st
@@ -1,0 +1,10 @@
+domain: "[N] -> { B[i] : 0 <= i < 2N; A[i] : 0 <= i < 4N; C[i] : 0 <= i < N }"
+child:
+  schedule: "[N] -> [{ B[i] -> [(2i)]; A[i] -> [(i)]; C[i] -> [(4i)] }]"
+  permutable: 1
+  coincident: [ 1 ]
+  child:
+    sequence:
+    - filter: "[N] -> { C[i] }"
+    - filter: "[N] -> { A[i] }"
+    - filter: "[N] -> { B[i] }"

--- a/test_inputs/schedule/noreverse.sc
+++ b/test_inputs/schedule/noreverse.sc
@@ -1,0 +1,6 @@
+# Check that setting --schedule-nonneg-var-coefficient prevents
+# the generation of a schedule with a reversal.
+# OPTIONS: --schedule-nonneg-var-coefficient
+domain: [N] -> { A[i] : -N < i < N; B[i] : -N < i < N }
+validity: { A[i] -> A[i + 1] }
+proximity: { A[i] -> B[-i] }

--- a/test_inputs/schedule/noreverse.st
+++ b/test_inputs/schedule/noreverse.st
@@ -1,0 +1,13 @@
+domain: "[N] -> { B[i] : -N < i < N; A[i] : -N < i < N }"
+child:
+  sequence:
+  - filter: "[N] -> { A[i] }"
+    child:
+      schedule: "[N] -> [{ A[i] -> [(i)] }]"
+      permutable: 1
+      coincident: [ 1 ]
+  - filter: "[N] -> { B[i] }"
+    child:
+      schedule: "[N] -> [{ B[i] -> [(i)] }]"
+      permutable: 1
+      coincident: [ 1 ]

--- a/test_inputs/schedule/reverse.sc
+++ b/test_inputs/schedule/reverse.sc
@@ -1,0 +1,5 @@
+# Check that a schedule with a reversal is generated
+# when --schedule-nonneg-var-coefficient is not set.
+domain: [N] -> { A[i] : -N < i < N; B[i] : -N < i < N }
+validity: { A[i] -> A[i + 1] }
+proximity: { A[i] -> B[-i] }

--- a/test_inputs/schedule/reverse.st
+++ b/test_inputs/schedule/reverse.st
@@ -1,0 +1,9 @@
+domain: "[N] -> { B[i] : -N < i < N; A[i] : -N < i < N }"
+child:
+  schedule: "[N] -> [{ B[i] -> [(-i)]; A[i] -> [(i)] }]"
+  permutable: 1
+  coincident: [ 1 ]
+  child:
+    sequence:
+    - filter: "[N] -> { A[i] }"
+    - filter: "[N] -> { B[i] }"


### PR DESCRIPTION
This option allows the user to request the generation of a schedule
with only non-negative values for the coefficients of the variables.
(The coefficients of the parameters are already non-negative.)
As with most options that restrict the values of the coefficients,
this option does not apply to the Feautrier scheduler
(which may get called as a backup).

This replaces the custom callback and includes some structural changes to isl.