### PR TITLE
replace isl_space_{un}named_set_from_params by isl_space_add{un}named_tuple*

### DIFF
--- a/doc/user.pod
+++ b/doc/user.pod
@@ -4911,11 +4911,10 @@ A set space of a given dimension and with an optional name
 can be created from a parameter space using the following functions.
 
 	#include <isl/space.h>
-	__isl_give isl_space *
-	isl_space_unnamed_set_from_params(
+	__isl_give isl_space *isl_space_add_unnamed_tuple_ui(
 		__isl_take isl_space *space, unsigned dim);
 	__isl_give isl_space *
-	isl_space_named_set_from_params_id(
+	isl_space_add_named_tuple_id_ui(
 		__isl_take isl_space *space,
 		__isl_take isl_id *tuple_id, unsigned dim);
 
@@ -4949,6 +4948,11 @@ on a given parameter domain using the following functions.
 		__isl_take isl_set *set);
 
 =item * Constructing a relation from one or two sets
+
+A map space with a range of a given dimension and with an optional name
+can be created from a domain space using the functions
+C<isl_space_add_unnamed_tuple_ui> and C<isl_space_add_named_tuple_id_ui>
+described above.
 
 A relation with a given domain tuple can be created from a set
 that will become the range of the relation

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -149,10 +149,10 @@ __isl_give isl_space *isl_space_range_map(__isl_take isl_space *space);
 __isl_export
 __isl_give isl_space *isl_space_params(__isl_take isl_space *space);
 __isl_export
-__isl_give isl_space *isl_space_unnamed_set_from_params(
+__isl_give isl_space *isl_space_add_unnamed_tuple_ui(
 	__isl_take isl_space *space, unsigned dim);
 __isl_export
-__isl_give isl_space *isl_space_named_set_from_params_id(
+__isl_give isl_space *isl_space_add_named_tuple_id_ui(
 	__isl_take isl_space *space, __isl_take isl_id *tuple_id, unsigned dim);
 __isl_export
 __isl_give isl_space *isl_space_set_from_params(__isl_take isl_space *space);

--- a/isl_space.c
+++ b/isl_space.c
@@ -1926,25 +1926,41 @@ error:
 	return NULL;
 }
 
-/* Create an unnamed set space of dimension "dim" from the parameter space
- * "space".
+/* Add an unnamed tuple of dimension "dim" to "space".
+ * In particular, if "space" is a parameter space, then return
+ * a set space with the given dimension.
+ * If "space" is a set set space, then return a map space
+ * with "space" as domain and a range of the given dimension.
  */
-__isl_give isl_space *isl_space_unnamed_set_from_params(
+__isl_give isl_space *isl_space_add_unnamed_tuple_ui(
 	__isl_take isl_space *space, unsigned dim)
 {
-	space = isl_space_set_from_params(space);
-	space = isl_space_add_dims(space, isl_dim_set, dim);
+	isl_bool is_params, is_set;
+
+	is_params = isl_space_is_params(space);
+	is_set = isl_space_is_set(space);
+	if (is_params < 0 || is_set < 0)
+		return isl_space_free(space);
+	if (!is_params && !is_set)
+		isl_die(isl_space_get_ctx(space), isl_error_invalid,
+			"cannot add tuple to map space",
+			return isl_space_free(space));
+	if (is_params)
+		space = isl_space_set_from_params(space);
+	else
+		space = isl_space_from_domain(space);
+	space = isl_space_add_dims(space, isl_dim_out, dim);
 	return space;
 }
 
-/* Create a set space of dimension "dim" and with tuple identifier "tuple_id"
- * from the parameter space "space".
+/* Add a tuple of dimension "dim" and with tuple identifier "tuple_id"
+ * to "space".
  */
-__isl_give isl_space *isl_space_named_set_from_params_id(
+__isl_give isl_space *isl_space_add_named_tuple_id_ui(
 	__isl_take isl_space *space, __isl_take isl_id *tuple_id, unsigned dim)
 {
-	space = isl_space_unnamed_set_from_params(space, dim);
-	space = isl_space_set_tuple_id(space, isl_dim_set, tuple_id);
+	space = isl_space_add_unnamed_tuple_ui(space, dim);
+	space = isl_space_set_tuple_id(space, isl_dim_out, tuple_id);
 	return space;
 }
 


### PR DESCRIPTION
The old names do not work out very well in the C++ bindings.
The new functions are also more generic and also support
creating a map space from a domain space.