### PR TITLE
drop enum class dim_type

### DIFF
--- a/all.h
+++ b/all.h
@@ -10,6 +10,5 @@
 #include <isl/schedule.h>
 #include <isl/schedule_node.h>
 #include <isl/ast_build.h>
-#include <isl/constraint.h>
 #include <isl/id.h>
 #include <isl/fixed_box.h>

--- a/cpp/cpp.h.pre
+++ b/cpp/cpp.h.pre
@@ -169,16 +169,6 @@ public:
 	}
 };
 
-enum class dim_type {
-  cst = isl_dim_cst,
-  param = isl_dim_param,
-  in = isl_dim_in,
-  out = isl_dim_out,
-  set = isl_dim_set,
-  div = isl_dim_div,
-  all = isl_dim_all
-};
-
 enum class ast_loop_type {
 	error = isl_ast_loop_error,
 	_default = isl_ast_loop_default,

--- a/cpp/isl-noexceptions.h.pre
+++ b/cpp/isl-noexceptions.h.pre
@@ -86,16 +86,6 @@ enum class stat {
   error = isl_stat_error
 };
 
-enum class dim_type {
-  cst = isl_dim_cst,
-  param = isl_dim_param,
-  in = isl_dim_in,
-  out = isl_dim_out,
-  set = isl_dim_set,
-  div = isl_dim_div,
-  all = isl_dim_all
-};
-
 enum class ast_loop_type {
 	error = isl_ast_loop_error,
 	_default = isl_ast_loop_default,

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -572,7 +572,6 @@ const char *isl_pw_multi_aff_get_tuple_name(__isl_keep isl_pw_multi_aff *pma,
 __isl_export
 __isl_give isl_id *isl_pw_multi_aff_get_range_tuple_id(
 	__isl_keep isl_pw_multi_aff *pma);
-__isl_export
 __isl_give isl_id *isl_pw_multi_aff_get_tuple_id(
 	__isl_keep isl_pw_multi_aff *pma, enum isl_dim_type type);
 isl_bool isl_pw_multi_aff_has_tuple_id(__isl_keep isl_pw_multi_aff *pma,

--- a/include/isl/constraint.h
+++ b/include/isl/constraint.h
@@ -22,17 +22,15 @@
 extern "C" {
 #endif
 
-struct __isl_export isl_constraint;
+struct isl_constraint;
 typedef struct isl_constraint isl_constraint;
 
 ISL_DECLARE_EXPORTED_LIST(constraint)
 
 isl_ctx *isl_constraint_get_ctx(__isl_keep isl_constraint *c);
 
-__isl_export
 __isl_give isl_constraint *isl_constraint_alloc_equality(
 	__isl_take isl_local_space *ls);
-__isl_export
 __isl_give isl_constraint *isl_constraint_alloc_inequality(
 	__isl_take isl_local_space *ls);
 __isl_give isl_constraint *isl_equality_alloc(__isl_take isl_local_space *ls);
@@ -57,9 +55,8 @@ __isl_give isl_constraint_list *isl_basic_map_get_constraint_list(
 __isl_export
 __isl_give isl_constraint_list *isl_basic_set_get_constraint_list(
 	__isl_keep isl_basic_set *bset);
-__isl_export
-isl_bool isl_constraint_is_equal(__isl_keep isl_constraint *constraint1,
-				 __isl_keep isl_constraint *constraint2);
+int isl_constraint_is_equal(struct isl_constraint *constraint1,
+			    struct isl_constraint *constraint2);
 
 isl_stat isl_basic_set_foreach_bound_pair(__isl_keep isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos,
@@ -67,16 +64,12 @@ isl_stat isl_basic_set_foreach_bound_pair(__isl_keep isl_basic_set *bset,
 		  __isl_take isl_constraint *upper,
 		  __isl_take isl_basic_set *bset, void *user), void *user);
 
-__isl_export
 __isl_give isl_basic_map *isl_basic_map_add_constraint(
 	__isl_take isl_basic_map *bmap, __isl_take isl_constraint *constraint);
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_add_constraint(
 	__isl_take isl_basic_set *bset, __isl_take isl_constraint *constraint);
-__isl_export
 __isl_give isl_map *isl_map_add_constraint(__isl_take isl_map *map,
 	__isl_take isl_constraint *constraint);
-__isl_export
 __isl_give isl_set *isl_set_add_constraint(__isl_take isl_set *set,
 	__isl_take isl_constraint *constraint);
 
@@ -110,13 +103,11 @@ __isl_give isl_val *isl_constraint_get_constant_val(
 	__isl_keep isl_constraint *constraint);
 __isl_give isl_val *isl_constraint_get_coefficient_val(
 	__isl_keep isl_constraint *constraint, enum isl_dim_type type, int pos);
-__isl_export
 __isl_give isl_constraint *isl_constraint_set_constant_si(
 	__isl_take isl_constraint *constraint, int v);
 __isl_export
 __isl_give isl_constraint *isl_constraint_set_constant_val(
 	__isl_take isl_constraint *constraint, __isl_take isl_val *v);
-__isl_export
 __isl_give isl_constraint *isl_constraint_set_coefficient_si(
 	__isl_take isl_constraint *constraint,
 	enum isl_dim_type type, int pos, int v);

--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -101,7 +101,6 @@ __isl_give isl_map *isl_map_set_domain_tuple_id(__isl_take isl_map *map,
 __isl_export
 __isl_give isl_map *isl_map_set_range_tuple_id(__isl_take isl_map *map,
 	__isl_take isl_id *id);
-__isl_export
 __isl_give isl_map *isl_map_set_tuple_id(__isl_take isl_map *map,
 	enum isl_dim_type type, __isl_take isl_id *id);
 __isl_give isl_map *isl_map_reset_tuple_id(__isl_take isl_map *map,
@@ -110,7 +109,6 @@ isl_bool isl_map_has_tuple_id(__isl_keep isl_map *map, enum isl_dim_type type);
 __isl_give isl_id *isl_map_get_domain_tuple_id(__isl_keep isl_map *map);
 __isl_export
 __isl_give isl_id *isl_map_get_range_tuple_id(__isl_keep isl_map *map);
-__isl_export
 __isl_give isl_id *isl_map_get_tuple_id(__isl_keep isl_map *map,
 	enum isl_dim_type type);
 __isl_give isl_map *isl_map_reset_user(__isl_take isl_map *map);

--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -173,7 +173,6 @@ isl_bool isl_multi_##BASE##_has_tuple_id(				\
 __isl_export								\
 __isl_give isl_id *isl_multi_##BASE##_get_range_tuple_id(		\
 	__isl_keep isl_multi_##BASE *multi);				\
-__isl_export                                                            \
 __isl_give isl_id *isl_multi_##BASE##_get_tuple_id(			\
 	__isl_keep isl_multi_##BASE *multi, enum isl_dim_type type);	\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_tuple_name(		\
@@ -182,7 +181,6 @@ __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_tuple_name(		\
 __isl_export                                                            \
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_range_tuple_id(	\
 	__isl_take isl_multi_##BASE *multi,  __isl_take isl_id *id);	\
-__isl_export                                                            \
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_tuple_id(		\
 	__isl_take isl_multi_##BASE *multi,				\
 	enum isl_dim_type type, __isl_take isl_id *id);			\

--- a/include/isl/schedule.h
+++ b/include/isl/schedule.h
@@ -94,12 +94,6 @@ __isl_export
 __isl_give isl_schedule_constraints *isl_schedule_constraints_set_prefix(
 	__isl_take isl_schedule_constraints *sc,
 	__isl_take isl_multi_union_pw_aff *prefix);
-__isl_give isl_schedule_constraints *
-isl_schedule_constraints_set_custom_constraint_callback(
-	__isl_take isl_schedule_constraints *sc,
-	__isl_give isl_basic_set *(*callback)(__isl_take isl_basic_set *,
-		int, int, __isl_keep isl_id_list *, int *, int *, void *),
-	void *data);
 __isl_null isl_schedule_constraints *isl_schedule_constraints_free(
 	__isl_take isl_schedule_constraints *sc);
 __isl_give isl_schedule_constraints *

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -51,7 +51,6 @@ __isl_give isl_set *isl_set_reset_space(__isl_take isl_set *set,
 __isl_give isl_aff *isl_basic_set_get_div(__isl_keep isl_basic_set *bset,
 	int pos);
 
-__isl_export
 __isl_give isl_local_space *isl_basic_set_get_local_space(
 	__isl_keep isl_basic_set *bset);
 

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -64,7 +64,6 @@ __isl_give isl_id *isl_space_get_map_domain_tuple_id(
 __isl_export
 __isl_give isl_id *isl_space_get_map_range_tuple_id(
 	__isl_keep isl_space *space);
-__isl_export
 __isl_give isl_id *isl_space_get_tuple_id(__isl_keep isl_space *dim,
 	enum isl_dim_type type);
 __isl_give isl_space *isl_space_reset_user(__isl_take isl_space *space);

--- a/isl_constraint.c
+++ b/isl_constraint.c
@@ -309,15 +309,15 @@ __isl_give isl_constraint_list *isl_basic_set_get_constraint_list(
 	return isl_basic_map_get_constraint_list(bset);
 }
 
-isl_bool isl_constraint_is_equal(__isl_keep isl_constraint *constraint1,
-	__isl_keep isl_constraint *constraint2)
+int isl_constraint_is_equal(struct isl_constraint *constraint1,
+	struct isl_constraint *constraint2)
 {
-	isl_bool equal;
+	int equal;
 
 	if (!constraint1 || !constraint2)
-		return isl_bool_error;
+		return 0;
 	if (constraint1->eq != constraint2->eq)
-		return isl_bool_false;
+		return 0;
 	equal = isl_local_space_is_equal(constraint1->ls, constraint2->ls);
 	if (equal < 0 || !equal)
 		return equal;

--- a/isl_schedule_constraints.h
+++ b/isl_schedule_constraints.h
@@ -24,14 +24,6 @@ __isl_give isl_schedule_constraints *isl_schedule_constraints_add(
 	__isl_take isl_schedule_constraints *sc, enum isl_edge_type type,
 	__isl_take isl_union_map *c);
 
-__isl_give
-isl_basic_set *(*isl_schedule_constraints_get_custom_constraint_callback(
-	__isl_keep isl_schedule_constraints *sc))
-	(__isl_take isl_basic_set *, int, int,
-	 __isl_keep isl_id_list *, int *, int *, void *);
-void *isl_schedule_constraints_get_custom_constraint_callback_user(
-	__isl_keep isl_schedule_constraints *sc);
-
 int isl_schedule_constraints_n_basic_map(
 	__isl_keep isl_schedule_constraints *sc);
 int isl_schedule_constraints_n_map(__isl_keep isl_schedule_constraints *sc);

--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -440,11 +440,6 @@ struct isl_sched_graph {
 
 	int max_weight;
 
-        __isl_give isl_basic_set *(*add_constraint)(
-		__isl_take isl_basic_set *, int, int,
-		__isl_keep isl_id_list *, int *, int *, void *);
-        void *add_constraint_data;
-
 	isl_bool (*merge_callback)(__isl_give isl_union_map *,
 		__isl_give isl_union_map *, int, int, int, void *);
 	void *merge_callback_data;
@@ -1748,11 +1743,6 @@ static isl_stat graph_init(struct isl_sched_graph *graph,
 		if (r < 0)
 			return isl_stat_error;
 	}
-
-	graph->add_constraint =
-		isl_schedule_constraints_get_custom_constraint_callback(sc);
-	graph->add_constraint_data =
-		isl_schedule_constraints_get_custom_constraint_callback_user(sc);
 
 	graph->merge_callback =
 		isl_schedule_constraints_get_merge_callback(sc);
@@ -3357,34 +3347,6 @@ static isl_stat setup_lp(isl_ctx *ctx, struct isl_sched_graph *graph,
 	if (add_all_proximity_constraints(graph, use_coincidence) < 0)
 		return isl_stat_error;
 
-	if (graph->add_constraint) {
-		int *node_n_param = isl_calloc_array(ctx, int, graph->n);
-		int *node_n_dims = isl_calloc_array(ctx, int, graph->n);
-		isl_id_list *node_id_list = isl_id_list_alloc(ctx, graph->n);
-
-		for (i = 0; i < graph->n; ++i) {
-			isl_space *node_space = graph->node[i].space;
-			isl_id *node_id =
-				isl_space_get_tuple_id(node_space, isl_dim_set);
-
-			node_id_list =
-				isl_id_list_add(node_id_list, node_id);
-			node_n_param[i] = graph->node[i].nparam;
-			node_n_dims[i] = graph->node[i].nvar;
-		}
-
-		graph->lp = (graph->add_constraint)(graph->lp, nparam,
-			graph->n_total_row, node_id_list, node_n_param,
-			node_n_dims, graph->add_constraint_data);
-
-		isl_id_list_free(node_id_list);
-		free(node_n_param);
-		free(node_n_dims);
-
-		if (!graph->lp)
-			return isl_stat_error;
-	}
-
 	return isl_stat_ok;
 }
 
@@ -4236,9 +4198,6 @@ static isl_stat extract_sub_graph(isl_ctx *ctx, struct isl_sched_graph *graph,
 	sub->max_row = graph->max_row;
 	sub->n_total_row = graph->n_total_row;
 	sub->band_start = graph->band_start;
-
-	sub->add_constraint = graph->add_constraint;
-	sub->add_constraint_data = graph->add_constraint_data;
 
 	sub->merge_callback = graph->merge_callback;
 	sub->merge_callback_data = graph->merge_callback_data;


### PR DESCRIPTION
This is unlikely to be exported in mainline isl and
is no longer needed for TC.
