### PR TITLE
change  export of isl_schedule_node_band_member_set_ast_loop_type 

### DIFF
--- a/cpp/cpp.h.pre
+++ b/cpp/cpp.h.pre
@@ -169,12 +169,4 @@ public:
 	}
 };
 
-enum class ast_loop_type {
-	error = isl_ast_loop_error,
-	_default = isl_ast_loop_default,
-	atomic = isl_ast_loop_atomic,
-	unroll = isl_ast_loop_unroll,
-	separate = isl_ast_loop_separate
-};
-
 } // namespace isl

--- a/cpp/isl-noexceptions.h.pre
+++ b/cpp/isl-noexceptions.h.pre
@@ -86,13 +86,5 @@ enum class stat {
   error = isl_stat_error
 };
 
-enum class ast_loop_type {
-	error = isl_ast_loop_error,
-	_default = isl_ast_loop_default,
-	atomic = isl_ast_loop_atomic,
-	unroll = isl_ast_loop_unroll,
-	separate = isl_ast_loop_separate
-};
-
 } // namespace noexceptions
 } // namespace isl

--- a/include/isl/schedule_node.h
+++ b/include/isl/schedule_node.h
@@ -129,6 +129,7 @@ __isl_give isl_union_map *isl_schedule_node_band_get_partial_schedule_union_map(
 	__isl_keep isl_schedule_node *node);
 enum isl_ast_loop_type isl_schedule_node_band_member_get_ast_loop_type(
 	__isl_keep isl_schedule_node *node, int pos);
+__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_band_member_set_ast_loop_type(
 	__isl_take isl_schedule_node *node, int pos,
 	enum isl_ast_loop_type type);

--- a/include/isl/schedule_node.h
+++ b/include/isl/schedule_node.h
@@ -129,7 +129,6 @@ __isl_give isl_union_map *isl_schedule_node_band_get_partial_schedule_union_map(
 	__isl_keep isl_schedule_node *node);
 enum isl_ast_loop_type isl_schedule_node_band_member_get_ast_loop_type(
 	__isl_keep isl_schedule_node *node, int pos);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_band_member_set_ast_loop_type(
 	__isl_take isl_schedule_node *node, int pos,
 	enum isl_ast_loop_type type);

--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -256,6 +256,7 @@ void cpp_generator::print_class(ostream &os, const isl_class &clazz)
 	osprintf(os, "\n");
 	print_persistent_callbacks_decl(os, clazz);
 	print_methods_decl(os, clazz);
+	print_set_enums_decl(os, clazz);
 
 	osprintf(os, "  typedef %s* isl_ptr_t;\n", name);
 	osprintf(os, "};\n");
@@ -626,6 +627,48 @@ void cpp_generator::print_methods_decl(ostream &os, const isl_class &clazz)
 		print_method_group_decl(os, clazz, it->second);
 }
 
+/* Print a declaration for a method "name" in "clazz" derived
+ * from "fd", which sets an enum, to "os".
+ *
+ * The last argument is removed because it is replaced by
+ * a break-up into several methods.
+ */
+void cpp_generator::print_set_enum_decl(ostream &os, const isl_class &clazz,
+	FunctionDecl *fd, const string &name)
+{
+	int n = fd->getNumParams();
+
+	print_method_header(os, clazz, fd, name, n - 1, true,
+				function_kind_member_method);
+}
+
+/* Print declarations for the methods in "clazz" derived from "fd",
+ * which sets an enum, to "os".
+ *
+ * A method is generated for each value in the enum, setting
+ * the enum to that value.
+ */
+void cpp_generator::print_set_enums_decl(ostream &os, const isl_class &clazz,
+	FunctionDecl *fd)
+{
+	vector<set_enum>::const_iterator it;
+	const vector<set_enum> &set_enums = clazz.set_enums.at(fd);
+
+	for (it = set_enums.begin(); it != set_enums.end(); ++it)
+		print_set_enum_decl(os, clazz, fd, it->method_name);
+}
+
+/* Print declarations for methods in "clazz" derived from functions
+ * that set an enum, to "os".
+ */
+void cpp_generator::print_set_enums_decl(ostream &os, const isl_class &clazz)
+{
+	map<FunctionDecl *, vector<set_enum> >::const_iterator it;
+
+	for (it = clazz.set_enums.begin(); it != clazz.set_enums.end(); ++it)
+		print_set_enums_decl(os, clazz, it->first);
+}
+
 /* Print declarations for methods "methods" in class "clazz" to "os".
  */
 void cpp_generator::print_method_group_decl(ostream &os, const isl_class &clazz,
@@ -684,6 +727,7 @@ void cpp_generator::print_class_impl(ostream &os, const isl_class &clazz)
 	osprintf(os, "\n");
 	print_persistent_callbacks_impl(os, clazz);
 	print_methods_impl(os, clazz);
+	print_set_enums_impl(os, clazz);
 }
 
 /* Print code with the given indentation
@@ -1120,6 +1164,77 @@ void cpp_generator::print_methods_impl(ostream &os, const isl_class &clazz)
 			osprintf(os, "\n");
 		print_method_group_impl(os, clazz, it->second);
 	}
+}
+
+/* Print the definition for a method "method_name" in "clazz" derived
+ * from "fd", which sets an enum, to "os".
+ * In particular, the method "method_name" sets the enum to "enum_name".
+ *
+ * The last argument of the C function does not appear in the method call,
+ * but is fixed to "enum_name" instead.
+ * Other than that, the method printed here is similar to one
+ * printed by cpp_generator::print_method_impl, except that
+ * some of the special cases do not occur.
+ */
+void cpp_generator::print_set_enum_impl(ostream &os, const isl_class &clazz,
+	FunctionDecl *fd, const string &enum_name, const string &method_name)
+{
+	string c_name = fd->getName();
+	int n = fd->getNumParams();
+	function_kind kind = function_kind_member_method;
+
+	print_method_header(os, clazz, fd, method_name, n - 1, false, kind);
+	osprintf(os, "{\n");
+
+	print_argument_validity_check(os, fd, kind);
+	print_save_ctx(os, fd, kind);
+	print_on_error_continue(os, fd, kind);
+
+	osprintf(os, "  auto res = %s(", c_name.c_str());
+
+	for (int i = 0; i < n - 1; ++i) {
+		ParmVarDecl *param = fd->getParamDecl(i);
+
+		if (i > 0)
+			osprintf(os, ", ");
+		print_method_param_use(os, param, i == 0);
+	}
+	osprintf(os, ", %s", enum_name.c_str());
+	osprintf(os, ");\n");
+
+	print_exceptional_execution_check(os, clazz, fd, kind);
+	print_method_return(os, clazz, fd);
+
+	osprintf(os, "}\n");
+}
+
+/* Print definitions for the methods in "clazz" derived from "fd",
+ * which sets an enum, to "os".
+ *
+ * A method is generated for each value in the enum, setting
+ * the enum to that value.
+ */
+void cpp_generator::print_set_enums_impl(ostream &os, const isl_class &clazz,
+	FunctionDecl *fd)
+{
+	vector<set_enum>::const_iterator it;
+	const vector<set_enum> &set_enums = clazz.set_enums.at(fd);
+
+	for (it = set_enums.begin(); it != set_enums.end(); ++it) {
+		osprintf(os, "\n");
+		print_set_enum_impl(os, clazz, fd, it->name, it->method_name);
+	}
+}
+
+/* Print definitions for methods in "clazz" derived from functions
+ * that set an enum, to "os".
+ */
+void cpp_generator::print_set_enums_impl(ostream &os, const isl_class &clazz)
+{
+	map<FunctionDecl *, vector<set_enum> >::const_iterator it;
+
+	for (it = clazz.set_enums.begin(); it != clazz.set_enums.end(); ++it)
+		print_set_enums_impl(os, clazz, it->first);
 }
 
 /* Print definitions for methods "methods" in class "clazz" to "os".

--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -1603,7 +1603,8 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
 	osprintf(os, "}\n");
 }
 
-/* Print the header for "method" in class "clazz" to "os".
+/* Print the header for "method" in class "clazz", with name "cname" and
+ * "num_params" number of arguments, to "os".
  *
  * Print the header of a declaration if "is_declaration" is set, otherwise print
  * the header of a method definition.
@@ -1643,15 +1644,13 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
  * know that implicit construction is allowed in absence of an explicit keyword.
  */
 void cpp_generator::print_method_header(ostream &os, const isl_class &clazz,
-	FunctionDecl *method, bool is_declaration, function_kind kind)
+	FunctionDecl *method, const string &cname, int num_params,
+	bool is_declaration, function_kind kind)
 {
-	string cname = clazz.method_name(method);
 	string rettype_str = get_return_type(clazz, method);
 	string classname = type2cpp(clazz);
-	int num_params = method->getNumParams();
 	int first_param = 0;
 
-	cname = rename_method(cname);
 	if (kind == function_kind_member_method)
 		first_param = 1;
 
@@ -1711,6 +1710,24 @@ void cpp_generator::print_method_header(ostream &os, const isl_class &clazz,
 	if (is_declaration)
 		osprintf(os, ";");
 	osprintf(os, "\n");
+}
+
+/* Print the header for "method" in class "clazz" to "os".
+ *
+ * Print the header of a declaration if "is_declaration" is set, otherwise print
+ * the header of a method definition.
+ *
+ * "kind" specifies the kind of method that should be generated.
+ */
+void cpp_generator::print_method_header(ostream &os, const isl_class &clazz,
+	FunctionDecl *method, bool is_declaration, function_kind kind)
+{
+	string cname = clazz.method_name(method);
+	int num_params = method->getNumParams();
+
+	cname = rename_method(cname);
+	print_method_header(os, clazz, method, cname, num_params,
+			    is_declaration, kind);
 }
 
 /* Generate the list of argument types for a callback function of

--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -1168,14 +1168,6 @@ void cpp_generator::print_method_param_use(ostream &os, ParmVarDecl *param,
 	const char *name_str = name.c_str();
 	QualType type = param->getOriginalType();
 
-        if (extensions) {
-          if (type->isEnumeralType()) {
-            string typestr = type.getAsString();
-            osprintf(os, "static_cast<%s>(%s)", typestr.c_str(), name_str);
-            return;
-          }
-        }
-
 	if (type->isIntegerType()) {
 		osprintf(os, "%s", name_str);
 		return;
@@ -1592,11 +1584,6 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
 		if (gives(method))
 			osprintf(os, "  free(res);\n");
 		osprintf(os, "  return tmp;\n");
-	} else if (is_isl_enum(return_type)) {
-		string typestr = return_type.getAsString();
-		typestr = typestr.replace(typestr.find("isl_"), sizeof("isl_")-1, "isl::");
-		osprintf(os, "  return static_cast<%s>(res);\n", typestr.c_str());
-
 	} else {
 		osprintf(os, "  return res;\n");
 	}
@@ -2106,17 +2093,6 @@ string cpp_generator::type2cpp(QualType type)
 
 	if (is_isl_stat(type))
 		return noexceptions ? "isl::stat" : "void";
-
-        if (extensions) {
-          if (type->isEnumeralType()) {
-            string typestr = type.getAsString();
-            return typestr.replace(
-                typestr.find("isl_"), sizeof("isl_")-1, "isl::");
-          }
-          else if (is_isl_ctx(type)) {
-            return "isl::ctx";
-          }
-        }
 
 	if (type->isIntegerType())
 		return type.getAsString();

--- a/interface/cpp.cc
+++ b/interface/cpp.cc
@@ -1531,7 +1531,6 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
 	int num_params = method->getNumParams();
 	QualType return_type = method->getReturnType();
 	string rettype_str = get_return_type(clazz, method);
-	bool has_callback = false;
 	bool returns_super = is_subclass_mutator(clazz, method);
 
 	print_method_header(os, clazz, method, false, kind);
@@ -1543,7 +1542,6 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
 	for (int i = 0; i < num_params; ++i) {
 		ParmVarDecl *param = method->getParamDecl(i);
 		if (is_callback(param->getType())) {
-			has_callback = true;
 			num_params -= 1;
 			print_callback_local(os, param);
 		}
@@ -1577,7 +1575,7 @@ void cpp_generator::print_method_impl(ostream &os, const isl_class &clazz,
 		if (returns_super)
 			osprintf(os, ".as<%s>()", rettype_str.c_str());
 		osprintf(os, ";\n");
-	} else if (has_callback) {
+	} else if (is_isl_bool(return_type) || is_isl_stat(return_type)) {
 		osprintf(os, "  return %s(res);\n", rettype_str.c_str());
 	} else if (is_string(return_type)) {
 		osprintf(os, "  std::string tmp(res);\n");

--- a/interface/cpp.h
+++ b/interface/cpp.h
@@ -61,6 +61,11 @@ private:
 		const set<FunctionDecl *> &methods);
 	void print_method_decl(ostream &os, const isl_class &clazz,
 		FunctionDecl *method, function_kind kind);
+	void print_set_enum_decl(ostream &os, const isl_class &clazz,
+		FunctionDecl *fd, const string &name);
+	void print_set_enums_decl(ostream &os, const isl_class &clazz,
+		FunctionDecl *fd);
+	void print_set_enums_decl(ostream &os, const isl_class &clazz);
 	void print_implementations(ostream &os);
 	void print_class_impl(ostream &os, const isl_class &clazz);
 	void print_check_ptr(ostream &os);
@@ -103,6 +108,12 @@ private:
 		FunctionDecl *method);
 	void print_method_impl(ostream &os, const isl_class &clazz,
 		FunctionDecl *method, function_kind kind);
+	void print_set_enum_impl(ostream &os, const isl_class &clazz,
+		FunctionDecl *fd, const string &enum_name,
+		const string &method_name);
+	void print_set_enums_impl(ostream &os, const isl_class &clazz,
+		FunctionDecl *fd);
+	void print_set_enums_impl(ostream &os, const isl_class &clazz);
 	void print_method_param_use(ostream &os, ParmVarDecl *param,
 		bool load_from_this_ptr);
 	std::string get_return_type(const isl_class &clazz, FunctionDecl *fd);

--- a/interface/cpp.h
+++ b/interface/cpp.h
@@ -99,6 +99,8 @@ private:
 		function_kind kind);
 	void print_set_persistent_callback(ostream &os, const isl_class &clazz,
 		FunctionDecl *method, function_kind kind);
+	void print_method_return(ostream &os, const isl_class &clazz,
+		FunctionDecl *method);
 	void print_method_impl(ostream &os, const isl_class &clazz,
 		FunctionDecl *method, function_kind kind);
 	void print_method_param_use(ostream &os, ParmVarDecl *param,

--- a/interface/cpp.h
+++ b/interface/cpp.h
@@ -107,6 +107,9 @@ private:
 		bool load_from_this_ptr);
 	std::string get_return_type(const isl_class &clazz, FunctionDecl *fd);
 	void print_method_header(ostream &os, const isl_class &clazz,
+		FunctionDecl *method, const string &cname, int num_params,
+		bool is_declaration, function_kind kind);
+	void print_method_header(ostream &os, const isl_class &clazz,
 		FunctionDecl *method, bool is_declaration, function_kind kind);
 	string generate_callback_args(QualType type, bool cpp);
 	string generate_callback_type(QualType type);

--- a/interface/generator.cc
+++ b/interface/generator.cc
@@ -168,6 +168,73 @@ void generator::add_type_subclasses(FunctionDecl *fn_type)
 	}
 }
 
+/* Add information about the enum values in "decl", set by "fd",
+ * to c->set_enums. "prefix" is the prefix of the generated method names.
+ * In particular, it has the name of the enum type removed.
+ *
+ * In particular, for each non-negative enum value, keep track of
+ * the value, the name and the corresponding method name.
+ */
+static void add_set_enum(isl_class *c, const string &prefix, EnumDecl *decl,
+	FunctionDecl *fd)
+{
+	DeclContext::decl_iterator i;
+
+	for (i = decl->decls_begin(); i != decl->decls_end(); ++i) {
+		EnumConstantDecl *ecd = dyn_cast<EnumConstantDecl>(*i);
+		int val = (int) ecd->getInitVal().getSExtValue();
+		string name = ecd->getNameAsString();
+		string method_name;
+
+		if (val < 0)
+			continue;
+		method_name = prefix + name.substr(4);
+		c->set_enums[fd].emplace_back(set_enum(val, name, method_name));
+	}
+}
+
+/* Check if "fd" sets an enum value and, if so, add information
+ * about the enum values to c->set_enums.
+ *
+ * A function is considered to set an enum value if:
+ * - the function returns an object of the same type
+ * - the last argument is of type enum
+ * - the name of the function ends with the name of the enum
+ */
+static bool handled_sets_enum(isl_class *c, FunctionDecl *fd)
+{
+	unsigned n;
+	ParmVarDecl *param;
+	const EnumType *enum_type;
+	EnumDecl *decl;
+	string enum_name;
+	string fd_name;
+	string prefix;
+	size_t pos;
+
+	if (!generator::is_mutator(*c, fd))
+		return false;
+	n = fd->getNumParams();
+	if (n < 2)
+		return false;
+	param = fd->getParamDecl(n - 1);
+	enum_type = param->getType()->getAs<EnumType>();
+	if (!enum_type)
+		return false;
+	decl = enum_type->getDecl();
+	enum_name = decl->getName();
+	enum_name = enum_name.substr(4);
+	fd_name = c->method_name(fd);
+	pos = fd_name.find(enum_name);
+	if (pos == std::string::npos)
+		return false;
+	prefix = fd_name.substr(0, pos);
+
+	add_set_enum(c, prefix, decl, fd);
+
+	return true;
+}
+
 /* Return the callback argument of a function setting
  * a persistent callback.
  * This callback is in the second argument (position 1).
@@ -245,6 +312,7 @@ generator::generator(SourceManager &SM, set<RecordDecl *> &exported_types,
 			continue;
 		if (is_constructor(method)) {
 			c->constructors.insert(method);
+		} else if (handled_sets_enum(c, method)) {
 		} else if (sets_persistent_callback(c, method)) {
 			c->persistent_callbacks.insert(method);
 		} else {

--- a/interface/generator.cc
+++ b/interface/generator.cc
@@ -510,17 +510,6 @@ bool generator::is_isl_stat(QualType type)
 	return s == "isl_stat";
 }
 
-/* Is "type" the type isl_enum?
- */
-bool generator::is_isl_enum(QualType type)
-{
-	if (is_isl_bool(type))
-		return false;
-
-	return type->isEnumeralType(); 
-}
-
-
 /* Is "type" that of a pointer to a function?
  */
 bool generator::is_callback(QualType type)

--- a/interface/generator.h
+++ b/interface/generator.h
@@ -4,11 +4,25 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 #include <clang/AST/Decl.h>
 
 using namespace std;
 using namespace clang;
+
+/* Information about a single enum value of an enum set by a function.
+ * "value" is the enum value.
+ * "name" is the corresponding name.
+ * "method_name" is the the name of the method that sets this value.
+ */
+struct set_enum {
+	int	value;
+	string	name;
+	string	method_name;
+	set_enum(int value, string name, string method_name) :
+		value(value), name(name), method_name(method_name) {}
+};
 
 /* isl_class collects all constructors and methods for an isl "class".
  * "name" is the name of the class.
@@ -19,6 +33,10 @@ using namespace clang;
  * "type" is the declaration that introduces the type.
  * "persistent_callbacks" contains the set of functions that
  * set a persistent callback.
+ * "set_enums" maps the set of functions that set an enum value
+ * to information associated to each value.
+ * A function is considered to set an enum value if it returns
+ * an object of the same type and if its last argument is of an enum type.
  * "methods" contains the set of methods, grouped by method name.
  * "fn_to_str" is a reference to the *_to_str method of this class, if any.
  * "fn_copy" is a reference to the *_copy method of this class, if any.
@@ -34,6 +52,7 @@ struct isl_class {
 	RecordDecl *type;
 	set<FunctionDecl *> constructors;
 	set<FunctionDecl *> persistent_callbacks;
+	map<FunctionDecl *, vector<set_enum> > set_enums;
 	map<string, set<FunctionDecl *> > methods;
 	map<int, string> type_subclasses;
 	FunctionDecl *fn_type;

--- a/interface/generator.h
+++ b/interface/generator.h
@@ -106,7 +106,6 @@ public:
 	static bool is_isl_bool(QualType type);
 	static bool is_isl_stat(QualType type);
 	static bool is_long(QualType type);
-	static bool is_isl_enum(QualType type);
 	static bool is_callback(QualType type);
 	static bool is_string(QualType type);
 	static bool is_static(const isl_class &clazz, FunctionDecl *method);

--- a/interface/python.cc
+++ b/interface/python.cc
@@ -108,6 +108,36 @@ void python_generator::print_type_check(const string &type, int pos,
 		printf("            raise\n");
 }
 
+/* For each of the "n" initial arguments of the function "method"
+ * that refer to an isl structure,
+ * including the object on which the method is called,
+ * check if the corresponding actual argument is of the right type.
+ * If not, try and convert it to the right type.
+ * If that doesn't work and if "super" contains at least one element,
+ * try and convert self to the type of the first superclass in "super" and
+ * call the corresponding method.
+ * If "first_is_ctx" is set, then the first argument is skipped.
+ */
+void python_generator::print_type_checks(const string &cname,
+	FunctionDecl *method, bool first_is_ctx, int n,
+	const vector<string> &super)
+{
+	for (int i = first_is_ctx; i < n; ++i) {
+		ParmVarDecl *param = method->getParamDecl(i);
+		string type;
+
+		if (!is_isl_type(param->getOriginalType()))
+			continue;
+		type = type2python(extract_type(param->getOriginalType()));
+		if (!first_is_ctx && i > 0 && super.size() > 0)
+			print_type_check(type, i - first_is_ctx, true, super[0],
+					cname, n);
+		else
+			print_type_check(type, i - first_is_ctx, false, "",
+					cname, -1);
+	}
+}
+
 /* Print a call to the *_copy function corresponding to "type".
  */
 void python_generator::print_copy(QualType type)
@@ -359,14 +389,6 @@ void python_generator::print_method_return(int indent, const isl_class &clazz,
  * a user argument in the Python interface, so we simply drop it.
  * We also create a wrapper ("cb") for the callback.
  *
- * For each argument of the function that refers to an isl structure,
- * including the object on which the method is called,
- * we check if the corresponding actual argument is of the right type.
- * If not, we try to convert it to the right type.
- * If that doesn't work and if "super" contains at least one element, we try
- * to convert self to the type of the first superclass in "super" and
- * call the corresponding method.
- *
  * If the function consumes a reference, then we pass it a copy of
  * the actual argument.
  */
@@ -389,19 +411,8 @@ void python_generator::print_method(const isl_class &clazz,
 	print_method_header(is_static(clazz, method), cname,
 			    num_params - drop_ctx - drop_user);
 
-	for (int i = drop_ctx; i < num_params; ++i) {
-		ParmVarDecl *param = method->getParamDecl(i);
-		string type;
-		if (!is_isl_type(param->getOriginalType()))
-			continue;
-		type = type2python(extract_type(param->getOriginalType()));
-		if (!drop_ctx && i > 0 && super.size() > 0)
-			print_type_check(type, i - drop_ctx, true, super[0],
-					cname, num_params - drop_user);
-		else
-			print_type_check(type, i - drop_ctx, false, "",
-					cname, -1);
-	}
+	print_type_checks(cname, method, drop_ctx,
+			    num_params - drop_user, super);
 	for (int i = 1; i < num_params; ++i) {
 		ParmVarDecl *param = method->getParamDecl(i);
 		QualType type = param->getOriginalType();

--- a/interface/python.cc
+++ b/interface/python.cc
@@ -517,6 +517,58 @@ void python_generator::print_method(const isl_class &clazz,
 		print_method_overload(clazz, *it);
 }
 
+/* Print a python method "name" corresponding to "fd" setting
+ * the enum value "value".
+ * "super" contains the superclasses of the class to which the method belongs,
+ * with the first element corresponding to the annotation that appears
+ * closest to the annotated type.
+ *
+ * The last argument of the C function does not appear in the method call,
+ * but is fixed to "value" instead.
+ * Other than that, the method printed here is similar to one
+ * printed by python_generator::print_method, except that
+ * some of the special cases do not occur.
+ */
+void python_generator::print_set_enum(const isl_class &clazz,
+	FunctionDecl *fd, int value, const string &name,
+	const vector<string> &super)
+{
+	string fullname = fd->getName();
+	int num_params = fd->getNumParams();
+
+	print_method_header(is_static(clazz, fd), name, num_params - 1);
+
+	print_type_checks(name, fd, false, num_params - 1, super);
+	printf("        ctx = arg0.ctx\n");
+	printf("        res = isl.%s(", fullname.c_str());
+	for (int i = 0; i < num_params - 1; ++i) {
+		if (i)
+			printf(", ");
+		print_arg_in_call(fd, i, 0);
+	}
+	printf(", %d", value);
+	printf(")\n");
+	print_method_return(8, clazz, fd);
+}
+
+/* Print python methods corresponding to "fd", which sets an enum.
+ * "super" contains the superclasses of the class to which the method belongs,
+ * with the first element corresponding to the annotation that appears
+ * closest to the annotated type.
+ *
+ * A method is generated for each value in the enum, setting
+ * the enum to that value.
+ */
+void python_generator::print_set_enum(const isl_class &clazz,
+	FunctionDecl *fd, const vector<string> &super)
+{
+	vector<set_enum>::const_iterator it;
+	const vector<set_enum> &set_enums = clazz.set_enums.at(fd);
+
+	for (it = set_enums.begin(); it != set_enums.end(); ++it)
+		print_set_enum(clazz, fd, it->value, it->method_name, super);
+}
+
 /* Print part of the constructor for this isl_class.
  *
  * In particular, check if the actual arguments correspond to the
@@ -785,7 +837,8 @@ void python_generator::print_copy_callbacks(const isl_class &clazz)
  *
  * To be able to call C functions it is necessary to explicitly set their
  * argument and result types.  Do this for all exported constructors and
- * methods (including those that set a persistent callback),
+ * methods (including those that set a persistent callback and
+ * those that set an enum value),
  * as well as for the *_to_str and the type function, if they exist.
  * Assuming each exported class has a *_copy and a *_free method,
  * also unconditionally set the type of such methods.
@@ -794,6 +847,7 @@ void python_generator::print_method_types(const isl_class &clazz)
 {
 	set<FunctionDecl *>::const_iterator in;
 	map<string, set<FunctionDecl *> >::const_iterator it;
+	map<FunctionDecl *, vector<set_enum> >::const_iterator ie;
 	const set<FunctionDecl *> &callbacks = clazz.persistent_callbacks;
 
 	for (in = clazz.constructors.begin(); in != clazz.constructors.end();
@@ -805,6 +859,8 @@ void python_generator::print_method_types(const isl_class &clazz)
 	for (it = clazz.methods.begin(); it != clazz.methods.end(); ++it)
 		for (in = it->second.begin(); in != it->second.end(); ++in)
 			print_method_type(*in);
+	for (ie = clazz.set_enums.begin(); ie != clazz.set_enums.end(); ++ie)
+		print_method_type(ie->first);
 
 	print_method_type(clazz.fn_copy);
 	print_method_type(clazz.fn_free);
@@ -825,7 +881,7 @@ void python_generator::print_method_types(const isl_class &clazz)
  *
  * Next, we print out some common methods and the methods corresponding
  * to functions that are not marked as constructors, including those
- * that set a persistent callback.
+ * that set a persistent callback and those that set an enum value.
  *
  * Finally, we tell ctypes about the types of the arguments of the
  * constructor functions and the return types of those function returning
@@ -836,6 +892,7 @@ void python_generator::print(const isl_class &clazz)
 	string p_name = type2python(clazz.subclass_name);
 	set<FunctionDecl *>::const_iterator in;
 	map<string, set<FunctionDecl *> >::const_iterator it;
+	map<FunctionDecl *, vector<set_enum> >::const_iterator ie;
 	vector<string> super = find_superclasses(clazz.type);
 	const set<FunctionDecl *> &callbacks = clazz.persistent_callbacks;
 
@@ -872,6 +929,8 @@ void python_generator::print(const isl_class &clazz)
 		print_method(clazz, *in, super);
 	for (it = clazz.methods.begin(); it != clazz.methods.end(); ++it)
 		print_method(clazz, it->first, it->second, super);
+	for (ie = clazz.set_enums.begin(); ie != clazz.set_enums.end(); ++ie)
+		print_set_enum(clazz, ie->first, super);
 
 	printf("\n");
 

--- a/interface/python.h
+++ b/interface/python.h
@@ -24,6 +24,8 @@ private:
 		const vector<string> &super);
 	void print_type_check(const string &type, int pos, bool upcast,
 		const string &super, const string &name, int n);
+	void print_type_checks(const string &cname, FunctionDecl *method,
+		bool first_is_ctx, int n, const vector<string> &super);
 	void print_copy(QualType type);
 	void print_callback(ParmVarDecl *param, int arg);
 	void print_arg_in_call(FunctionDecl *fd, int arg, int skip);

--- a/interface/python.h
+++ b/interface/python.h
@@ -49,5 +49,9 @@ private:
 		FunctionDecl *method);
 	void print_method(const isl_class &clazz, const string &fullname,
 		const set<FunctionDecl *> &methods, vector<string> super);
+	void print_set_enum(const isl_class &clazz, FunctionDecl *fd,
+		int value, const string &name, const vector<string> &super);
+	void print_set_enum(const isl_class &clazz, FunctionDecl *fd,
+		const vector<string> &super);
 
 };

--- a/isl_test_python.py
+++ b/isl_test_python.py
@@ -284,11 +284,37 @@ def test_schedule_tree():
 	root.every_descendant(collect_filters)
 	assert(domain.is_equal(filters[0]))
 
+# Test marking band members for unrolling.
+# "schedule" is the schedule created by construct_schedule_tree.
+# It schedules two statements, with 10 and 20 instances, respectively.
+# Unrolling all band members therefore results in 30 at-domain calls
+# by the AST generator.
+#
+def test_ast_build_unroll(schedule):
+	root = schedule.get_root()
+	def mark_unroll(node):
+		if type(node) == isl.schedule_node_band:
+			node = node.member_set_ast_loop_unroll(0)
+		return node
+	root = root.map_descendant_bottom_up(mark_unroll)
+	schedule = root.get_schedule()
+
+	count_ast = [0]
+	def inc_count_ast(node, build):
+		count_ast[0] += 1
+		return node
+
+	build = isl.ast_build()
+	build = build.set_at_each_domain(inc_count_ast)
+	ast = build.node_from(schedule)
+	assert(count_ast[0] == 30)
+
 # Test basic AST generation from a schedule tree.
 #
 # In particular, create a simple schedule tree and
 # - generate an AST from the schedule tree
 # - test at_each_domain
+# - test unrolling
 #
 def test_ast_build():
 	schedule = construct_schedule_tree()
@@ -335,6 +361,8 @@ def test_ast_build():
 	do_fail = False;
 	ast = build.node_from(schedule)
 	assert(count_ast_fail[0] == 2)
+
+	test_ast_build_unroll(schedule);
 
 # Test the isl Python interface
 #


### PR DESCRIPTION
This may seem like a lot of code just to change a single line in TC,
but it does look nicer to be able to write
`bandNode.member_set_ast_loop_unroll(i);`
instead of
`bandNode.member_set_ast_loop_type(i, isl::ast_loop_type::unroll);`

In fact, it may even be a nicer interface for C as well, but it would require extra code,
while the C++ interface is automatically generated (admittedly using a lot more code,
but it can perhaps be reused in the future).

The new way of exporting this function is also (properly) supported in the Python bindings.
