### PR TITLE
fix merge callback fallout

### DIFF
--- a/isl_scheduler.c
+++ b/isl_scheduler.c
@@ -7640,7 +7640,7 @@ static isl_bool ok_to_merge(isl_ctx *ctx, struct isl_sched_graph *graph,
 		return isl_bool_false;
 
 	if (isl_options_get_schedule_maximize_coincidence(ctx) &&
-	    (n_coincident_after - n_coincident_after) < 0)
+	    (n_coincident_after - n_coincident_before) < 0)
 		return isl_bool_false;
 
 	return ok_to_merge_proximity(ctx, graph, c, merge_graph);


### PR DESCRIPTION
The introduction of merge callbacks in isl-0.18-816-g3d84f765 (Merge
heuristic callback (#6), Tue Jul 25 13:21:55 2017 +0200) broke
the handling of maximize coincidence in the absence of merge callbacks.
The commit it probably going to be reverted in the near future,
but in the mean time, the fix is needed to be able to merge master,
which introduces a new test case that breaks.