### PR TITLE
drop stuff that is not currently used by TC

### DIFF
--- a/flags.sh
+++ b/flags.sh
@@ -1,4 +1,0 @@
-#! /bin/bash
-
-export ISL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$@

--- a/include/isl/aff.h
+++ b/include/isl/aff.h
@@ -18,7 +18,6 @@ extern "C" {
 
 __isl_overload
 __isl_give isl_aff *isl_aff_zero_on_domain_space(__isl_take isl_space *space);
-__isl_constructor
 __isl_give isl_aff *isl_aff_zero_on_domain(__isl_take isl_local_space *ls);
 __isl_constructor
 __isl_give isl_aff *isl_aff_val_on_domain(__isl_take isl_local_space *ls,
@@ -45,22 +44,17 @@ __isl_export
 __isl_give isl_space *isl_aff_get_space(__isl_keep isl_aff *aff);
 __isl_give isl_local_space *isl_aff_get_domain_local_space(
 	__isl_keep isl_aff *aff);
-__isl_export
 __isl_give isl_local_space *isl_aff_get_local_space(__isl_keep isl_aff *aff);
 
 const char *isl_aff_get_dim_name(__isl_keep isl_aff *aff,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_val *isl_aff_get_constant_val(__isl_keep isl_aff *aff);
 __isl_give isl_val *isl_aff_get_coefficient_val(__isl_keep isl_aff *aff,
 	enum isl_dim_type type, int pos);
 int isl_aff_coefficient_sgn(__isl_keep isl_aff *aff,
 	enum isl_dim_type type, int pos);
-__isl_export
 __isl_give isl_val *isl_aff_get_denominator_val(__isl_keep isl_aff *aff);
-__isl_export
 __isl_give isl_aff *isl_aff_set_constant_si(__isl_take isl_aff *aff, int v);
-__isl_export
 __isl_give isl_aff *isl_aff_set_constant_val(__isl_take isl_aff *aff,
 	__isl_take isl_val *v);
 __isl_give isl_aff *isl_aff_set_coefficient_si(__isl_take isl_aff *aff,
@@ -90,13 +84,11 @@ __isl_give isl_aff *isl_aff_set_dim_id(__isl_take isl_aff *aff,
 int isl_aff_find_dim_by_name(__isl_keep isl_aff *aff, enum isl_dim_type type,
 	const char *name);
 
-__isl_export
 isl_bool isl_aff_plain_is_equal(__isl_keep isl_aff *aff1,
 	__isl_keep isl_aff *aff2);
 isl_bool isl_aff_plain_is_zero(__isl_keep isl_aff *aff);
 isl_bool isl_aff_is_nan(__isl_keep isl_aff *aff);
 
-__isl_export
 __isl_give isl_aff *isl_aff_get_div(__isl_keep isl_aff *aff, int pos);
 
 __isl_give isl_aff *isl_aff_from_range(__isl_take isl_aff *aff);
@@ -127,7 +119,6 @@ __isl_give isl_aff *isl_aff_sub(__isl_take isl_aff *aff1,
 __isl_overload
 __isl_give isl_aff *isl_aff_scale_val(__isl_take isl_aff *aff,
 	__isl_take isl_val *v);
-__isl_export
 __isl_give isl_aff *isl_aff_scale_down_ui(__isl_take isl_aff *aff, unsigned f);
 __isl_overload
 __isl_give isl_aff *isl_aff_scale_down_val(__isl_take isl_aff *aff,
@@ -142,7 +133,6 @@ __isl_give isl_aff *isl_aff_move_dims(__isl_take isl_aff *aff,
 	enum isl_dim_type src_type, unsigned src_pos, unsigned n);
 __isl_give isl_aff *isl_aff_drop_dims(__isl_take isl_aff *aff,
 	enum isl_dim_type type, unsigned first, unsigned n);
-__isl_export
 __isl_give isl_aff *isl_aff_project_domain_on_params(__isl_take isl_aff *aff);
 __isl_export
 __isl_give isl_aff *isl_aff_unbind_params_insert_domain(
@@ -208,7 +198,6 @@ void isl_aff_dump(__isl_keep isl_aff *aff);
 isl_ctx *isl_pw_aff_get_ctx(__isl_keep isl_pw_aff *pwaff);
 uint32_t isl_pw_aff_get_hash(__isl_keep isl_pw_aff *pa);
 __isl_give isl_space *isl_pw_aff_get_domain_space(__isl_keep isl_pw_aff *pwaff);
-__isl_export
 __isl_give isl_space *isl_pw_aff_get_space(__isl_keep isl_pw_aff *pwaff);
 
 __isl_constructor
@@ -216,13 +205,11 @@ __isl_give isl_pw_aff *isl_pw_aff_from_aff(__isl_take isl_aff *aff);
 __isl_give isl_pw_aff *isl_pw_aff_empty(__isl_take isl_space *dim);
 __isl_give isl_pw_aff *isl_pw_aff_alloc(__isl_take isl_set *set,
 	__isl_take isl_aff *aff);
-__isl_constructor
 __isl_give isl_pw_aff *isl_pw_aff_zero_on_domain(
 	__isl_take isl_local_space *ls);
 __isl_give isl_pw_aff *isl_pw_aff_var_on_domain(__isl_take isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos);
 __isl_give isl_pw_aff *isl_pw_aff_nan_on_domain(__isl_take isl_local_space *ls);
-__isl_constructor
 __isl_give isl_pw_aff *isl_pw_aff_val_on_domain(__isl_take isl_set *domain,
 	__isl_take isl_val *v);
 
@@ -241,7 +228,6 @@ int isl_pw_aff_find_dim_by_name(__isl_keep isl_pw_aff *pa,
 	enum isl_dim_type type, const char *name);
 
 isl_bool isl_pw_aff_is_empty(__isl_keep isl_pw_aff *pwaff);
-__isl_export
 isl_bool isl_pw_aff_involves_nan(__isl_keep isl_pw_aff *pa);
 int isl_pw_aff_plain_cmp(__isl_keep isl_pw_aff *pa1,
 	__isl_keep isl_pw_aff *pa2);
@@ -268,10 +254,8 @@ isl_bool isl_pw_aff_involves_param_id(__isl_keep isl_pw_aff *pa,
 isl_bool isl_pw_aff_involves_dims(__isl_keep isl_pw_aff *pwaff,
 	enum isl_dim_type type, unsigned first, unsigned n);
 
-__isl_export
 isl_bool isl_pw_aff_is_cst(__isl_keep isl_pw_aff *pwaff);
 
-__isl_export
 __isl_give isl_pw_aff *isl_pw_aff_project_domain_on_params(
 	__isl_take isl_pw_aff *pa);
 
@@ -291,7 +275,6 @@ __isl_give isl_pw_aff *isl_pw_aff_reset_tuple_id(__isl_take isl_pw_aff *pa,
 	enum isl_dim_type type);
 __isl_give isl_pw_aff *isl_pw_aff_reset_user(__isl_take isl_pw_aff *pa);
 
-__isl_export
 __isl_give isl_set *isl_pw_aff_params(__isl_take isl_pw_aff *pwa);
 __isl_export
 __isl_give isl_set *isl_pw_aff_domain(__isl_take isl_pw_aff *pwaff);
@@ -331,10 +314,8 @@ __isl_export
 __isl_give isl_pw_aff *isl_pw_aff_tdiv_r(__isl_take isl_pw_aff *pa1,
 	__isl_take isl_pw_aff *pa2);
 
-__isl_export
 __isl_give isl_pw_aff *isl_pw_aff_intersect_params(__isl_take isl_pw_aff *pa,
 	__isl_take isl_set *set);
-__isl_export
 __isl_give isl_pw_aff *isl_pw_aff_intersect_domain(__isl_take isl_pw_aff *pa,
 	__isl_take isl_set *set);
 __isl_give isl_pw_aff *isl_pw_aff_subtract_domain(__isl_take isl_pw_aff *pa,
@@ -382,7 +363,6 @@ __isl_give isl_pw_aff *isl_pw_aff_pullback_multi_pw_aff(
 
 __isl_export
 int isl_pw_aff_n_piece(__isl_keep isl_pw_aff *pwaff);
-__isl_export
 isl_stat isl_pw_aff_foreach_piece(__isl_keep isl_pw_aff *pwaff,
 	isl_stat (*fn)(__isl_take isl_set *set, __isl_take isl_aff *aff,
 		    void *user), void *user);
@@ -558,7 +538,6 @@ isl_bool isl_pw_multi_aff_involves_dims(__isl_keep isl_pw_multi_aff *pma,
 __isl_export
 __isl_give isl_pw_aff *isl_pw_multi_aff_get_pw_aff(
 	__isl_keep isl_pw_multi_aff *pma, int pos);
-__isl_export
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_set_pw_aff(
 	__isl_take isl_pw_multi_aff *pma, unsigned pos,
 	__isl_take isl_pw_aff *pa);
@@ -566,7 +545,6 @@ __isl_give isl_pw_multi_aff *isl_pw_multi_aff_set_pw_aff(
 isl_ctx *isl_pw_multi_aff_get_ctx(__isl_keep isl_pw_multi_aff *pma);
 __isl_give isl_space *isl_pw_multi_aff_get_domain_space(
 	__isl_keep isl_pw_multi_aff *pma);
-__isl_export
 __isl_give isl_space *isl_pw_multi_aff_get_space(
 	__isl_keep isl_pw_multi_aff *pma);
 isl_bool isl_pw_multi_aff_has_tuple_name(__isl_keep isl_pw_multi_aff *pma,
@@ -595,14 +573,12 @@ __isl_give isl_pw_multi_aff *isl_pw_multi_aff_drop_dims(
 	__isl_take isl_pw_multi_aff *pma,
 	enum isl_dim_type type, unsigned first, unsigned n);
 
-__isl_export
 __isl_give isl_set *isl_pw_multi_aff_domain(__isl_take isl_pw_multi_aff *pma);
 
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_empty(__isl_take isl_space *space);
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_from_domain(
 	__isl_take isl_set *set);
 
-__isl_constructor
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_multi_val_on_domain(
 	__isl_take isl_set *domain, __isl_take isl_multi_val *mv);
 
@@ -681,7 +657,6 @@ __isl_give isl_pw_multi_aff *isl_pw_multi_aff_intersect_domain(
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_subtract_domain(
 	__isl_take isl_pw_multi_aff *pma, __isl_take isl_set *set);
 
-__isl_export
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_project_domain_on_params(
 	__isl_take isl_pw_multi_aff *pma);
 
@@ -704,9 +679,7 @@ __isl_overload
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_pullback_pw_multi_aff(
 	__isl_take isl_pw_multi_aff *pma1, __isl_take isl_pw_multi_aff *pma2);
 
-__isl_export
 int isl_pw_multi_aff_n_piece(__isl_keep isl_pw_multi_aff *pma);
-__isl_export
 isl_stat isl_pw_multi_aff_foreach_piece(__isl_keep isl_pw_multi_aff *pma,
 	isl_stat (*fn)(__isl_take isl_set *set, __isl_take isl_multi_aff *maff,
 		    void *user), void *user);
@@ -738,7 +711,6 @@ __isl_give isl_union_pw_multi_aff *isl_union_pw_multi_aff_from_pw_multi_aff(
 	__isl_take isl_pw_multi_aff *pma);
 __isl_give isl_union_pw_multi_aff *isl_union_pw_multi_aff_from_domain(
 	__isl_take isl_union_set *uset);
-__isl_constructor
 __isl_give isl_union_pw_multi_aff *isl_union_pw_multi_aff_multi_val_on_domain(
 	__isl_take isl_union_set *domain, __isl_take isl_multi_val *mv);
 __isl_overload
@@ -752,7 +724,6 @@ __isl_null isl_union_pw_multi_aff *isl_union_pw_multi_aff_free(
 __isl_give isl_union_pw_multi_aff *isl_union_set_identity_union_pw_multi_aff(
 	__isl_take isl_union_set *uset);
 
-__isl_export
 __isl_give isl_union_pw_aff *isl_union_pw_multi_aff_get_union_pw_aff(
 	__isl_keep isl_union_pw_multi_aff *upma, int pos);
 
@@ -762,7 +733,6 @@ __isl_give isl_union_pw_multi_aff *isl_union_pw_multi_aff_add_pw_multi_aff(
 
 isl_ctx *isl_union_pw_multi_aff_get_ctx(
 	__isl_keep isl_union_pw_multi_aff *upma);
-__isl_export
 __isl_give isl_space *isl_union_pw_multi_aff_get_space(
 	__isl_keep isl_union_pw_multi_aff *upma);
 __isl_give isl_pw_multi_aff_list *isl_union_pw_multi_aff_get_pw_multi_aff_list(
@@ -803,16 +773,13 @@ isl_union_pw_multi_aff_pullback_union_pw_multi_aff(
 __isl_give isl_union_pw_multi_aff *isl_union_pw_multi_aff_align_params(
 	__isl_take isl_union_pw_multi_aff *upma, __isl_take isl_space *model);
 
-__isl_export
 int isl_union_pw_multi_aff_n_pw_multi_aff(
 	__isl_keep isl_union_pw_multi_aff *upma);
 
-__isl_export
 isl_stat isl_union_pw_multi_aff_foreach_pw_multi_aff(
 	__isl_keep isl_union_pw_multi_aff *upma,
 	isl_stat (*fn)(__isl_take isl_pw_multi_aff *pma, void *user),
 	void *user);
-__isl_export
 __isl_give isl_pw_multi_aff *isl_union_pw_multi_aff_extract_pw_multi_aff(
 	__isl_keep isl_union_pw_multi_aff *upma, __isl_take isl_space *space);
 
@@ -822,7 +789,6 @@ isl_bool isl_union_pw_multi_aff_plain_is_equal(
 	__isl_keep isl_union_pw_multi_aff *upma1,
 	__isl_keep isl_union_pw_multi_aff *upma2);
 
-__isl_export
 __isl_give isl_union_set *isl_union_pw_multi_aff_domain(
 	__isl_take isl_union_pw_multi_aff *upma);
 
@@ -873,7 +839,6 @@ __isl_give isl_printer *isl_printer_print_union_pw_multi_aff(
 
 __isl_give isl_union_pw_multi_aff *isl_union_pw_multi_aff_from_union_set(
 	__isl_take isl_union_set *uset);
-__isl_overload
 __isl_give isl_union_pw_multi_aff *isl_union_pw_multi_aff_from_union_map(
 	__isl_take isl_union_map *umap);
 
@@ -886,7 +851,6 @@ __isl_give char *isl_union_pw_multi_aff_to_str(
 
 uint32_t isl_multi_pw_aff_get_hash(__isl_keep isl_multi_pw_aff *mpa);
 
-__isl_export
 __isl_give isl_multi_pw_aff *isl_multi_pw_aff_identity(
 	__isl_take isl_space *space);
 __isl_constructor
@@ -895,7 +859,6 @@ __isl_give isl_multi_pw_aff *isl_multi_pw_aff_from_multi_aff(
 __isl_constructor
 __isl_give isl_multi_pw_aff *isl_multi_pw_aff_from_pw_aff(
 	__isl_take isl_pw_aff *pa);
-__isl_export
 __isl_give isl_set *isl_multi_pw_aff_domain(__isl_take isl_multi_pw_aff *mpa);
 __isl_give isl_multi_pw_aff *isl_multi_pw_aff_intersect_params(
 	__isl_take isl_multi_pw_aff *mpa, __isl_take isl_set *set);
@@ -931,7 +894,6 @@ __isl_give isl_multi_pw_aff *isl_multi_pw_aff_move_dims(
 
 __isl_give isl_set *isl_set_from_multi_pw_aff(__isl_take isl_multi_pw_aff *mpa);
 __isl_give isl_map *isl_map_from_multi_pw_aff(__isl_take isl_multi_pw_aff *mpa);
-__isl_overload
 __isl_give isl_pw_multi_aff *isl_pw_multi_aff_from_multi_pw_aff(
 	__isl_take isl_multi_pw_aff *mpa);
 __isl_constructor
@@ -959,7 +921,6 @@ __isl_null isl_union_pw_aff *isl_union_pw_aff_free(
 	__isl_take isl_union_pw_aff *upa);
 
 isl_ctx *isl_union_pw_aff_get_ctx(__isl_keep isl_union_pw_aff *upa);
-__isl_export
 __isl_give isl_space *isl_union_pw_aff_get_space(
 	__isl_keep isl_union_pw_aff *upa);
 __isl_export
@@ -993,7 +954,6 @@ __isl_give isl_union_pw_aff *isl_union_pw_aff_from_pw_aff(
 __isl_constructor
 __isl_give isl_union_pw_aff *isl_union_pw_aff_val_on_domain(
 	__isl_take isl_union_set *domain, __isl_take isl_val *v);
-__isl_constructor
 __isl_give isl_union_pw_aff *isl_union_pw_aff_aff_on_domain(
 	__isl_take isl_union_set *domain, __isl_take isl_aff *aff);
 __isl_give isl_union_pw_aff *isl_union_pw_aff_pw_aff_on_domain(
@@ -1005,13 +965,10 @@ __isl_constructor
 __isl_give isl_union_pw_multi_aff *isl_union_pw_multi_aff_from_union_pw_aff(
 	__isl_take isl_union_pw_aff *upa);
 
-__isl_export
 int isl_union_pw_aff_n_pw_aff(__isl_keep isl_union_pw_aff *upa);
 
-__isl_export
 isl_stat isl_union_pw_aff_foreach_pw_aff(__isl_keep isl_union_pw_aff *upa,
 	isl_stat (*fn)(__isl_take isl_pw_aff *pa, void *user), void *user);
-__isl_export
 __isl_give isl_pw_aff *isl_union_pw_aff_extract_pw_aff(
 	__isl_keep isl_union_pw_aff *upa, __isl_take isl_space *space);
 __isl_overload
@@ -1019,7 +976,6 @@ __isl_give isl_pw_aff *isl_union_pw_aff_extract_on_domain_space(
 	__isl_keep isl_union_pw_aff *upa, __isl_take isl_space *space);
 
 isl_bool isl_union_pw_aff_involves_nan(__isl_keep isl_union_pw_aff *upa);
-__isl_export
 isl_bool isl_union_pw_aff_plain_is_equal(__isl_keep isl_union_pw_aff *upa1,
 	__isl_keep isl_union_pw_aff *upa2);
 
@@ -1116,7 +1072,6 @@ __isl_give isl_multi_union_pw_aff *isl_multi_union_pw_aff_from_multi_pw_aff(
 __isl_constructor
 __isl_give isl_multi_union_pw_aff *isl_multi_union_pw_aff_multi_val_on_domain(
 	__isl_take isl_union_set *domain, __isl_take isl_multi_val *mv);
-__isl_constructor
 __isl_give isl_multi_union_pw_aff *isl_multi_union_pw_aff_multi_aff_on_domain(
 	__isl_take isl_union_set *domain, __isl_take isl_multi_aff *ma);
 __isl_give isl_multi_union_pw_aff *
@@ -1157,7 +1112,6 @@ __isl_give isl_multi_union_pw_aff *isl_multi_union_pw_aff_apply_multi_aff(
 	__isl_take isl_multi_union_pw_aff *mupa, __isl_take isl_multi_aff *ma);
 __isl_give isl_union_pw_aff *isl_multi_union_pw_aff_apply_pw_aff(
 	__isl_take isl_multi_union_pw_aff *mupa, __isl_take isl_pw_aff *pa);
-__isl_overload
 __isl_give isl_multi_union_pw_aff *isl_multi_union_pw_aff_apply_pw_multi_aff(
 	__isl_take isl_multi_union_pw_aff *mupa,
 	__isl_take isl_pw_multi_aff *pma);
@@ -1168,7 +1122,6 @@ isl_multi_union_pw_aff_pullback_union_pw_multi_aff(
 	__isl_take isl_multi_union_pw_aff *mupa,
 	__isl_take isl_union_pw_multi_aff *upma);
 
-__isl_export
 __isl_give isl_union_pw_multi_aff *
 isl_union_pw_multi_aff_from_multi_union_pw_aff(
 	__isl_take isl_multi_union_pw_aff *mupa);
@@ -1182,18 +1135,15 @@ __isl_give isl_multi_union_pw_aff *
 isl_multi_union_pw_aff_from_union_pw_multi_aff(
 	__isl_take isl_union_pw_multi_aff *upma);
 
-__isl_export
 __isl_give isl_multi_union_pw_aff *isl_multi_union_pw_aff_from_union_map(
 	__isl_take isl_union_map *umap);
 __isl_overload
 __isl_give isl_union_map *isl_union_map_from_multi_union_pw_aff(
 	__isl_take isl_multi_union_pw_aff *mupa);
 
-__isl_export
 __isl_give isl_union_set *isl_multi_union_pw_aff_zero_union_set(
 	__isl_take isl_multi_union_pw_aff *mupa);
 
-__isl_export
 __isl_give isl_multi_pw_aff *isl_multi_union_pw_aff_extract_multi_pw_aff(
 	__isl_keep isl_multi_union_pw_aff *mupa, __isl_take isl_space *space);
 

--- a/include/isl/ast_build.h
+++ b/include/isl/ast_build.h
@@ -50,7 +50,6 @@ __isl_give isl_ast_build *isl_ast_build_alloc(isl_ctx *ctx);
 __isl_export
 __isl_give isl_ast_build *isl_ast_build_from_context(__isl_take isl_set *set);
 
-__isl_export
 __isl_give isl_space *isl_ast_build_get_schedule_space(
 	__isl_keep isl_ast_build *build);
 __isl_export
@@ -123,7 +122,6 @@ __isl_give isl_ast_node *isl_ast_build_node_from_schedule(
 __isl_export
 __isl_give isl_ast_node *isl_ast_build_node_from_schedule_map(
 	__isl_keep isl_ast_build *build, __isl_take isl_union_map *schedule);
-__isl_export
 __isl_give isl_ast_node *isl_ast_build_ast_from_schedule(
 	__isl_keep isl_ast_build *build, __isl_take isl_union_map *schedule);
 

--- a/include/isl/constraint.h
+++ b/include/isl/constraint.h
@@ -25,7 +25,7 @@ extern "C" {
 struct isl_constraint;
 typedef struct isl_constraint isl_constraint;
 
-ISL_DECLARE_EXPORTED_LIST(constraint)
+ISL_DECLARE_LIST(constraint)
 
 isl_ctx *isl_constraint_get_ctx(__isl_keep isl_constraint *c);
 
@@ -39,20 +39,14 @@ __isl_give isl_constraint *isl_inequality_alloc(__isl_take isl_local_space *ls);
 struct isl_constraint *isl_constraint_copy(struct isl_constraint *c);
 __isl_null isl_constraint *isl_constraint_free(__isl_take isl_constraint *c);
 
-__isl_export
 int isl_basic_map_n_constraint(__isl_keep isl_basic_map *bmap);
-__isl_export
 int isl_basic_set_n_constraint(__isl_keep isl_basic_set *bset);
-__isl_export
 isl_stat isl_basic_map_foreach_constraint(__isl_keep isl_basic_map *bmap,
 	isl_stat (*fn)(__isl_take isl_constraint *c, void *user), void *user);
-__isl_export
 isl_stat isl_basic_set_foreach_constraint(__isl_keep isl_basic_set *bset,
 	isl_stat (*fn)(__isl_take isl_constraint *c, void *user), void *user);
-__isl_export
 __isl_give isl_constraint_list *isl_basic_map_get_constraint_list(
 	__isl_keep isl_basic_map *bmap);
-__isl_export
 __isl_give isl_constraint_list *isl_basic_set_get_constraint_list(
 	__isl_keep isl_basic_set *bset);
 int isl_constraint_is_equal(struct isl_constraint *constraint1,
@@ -84,10 +78,8 @@ isl_bool isl_basic_set_has_defining_inequalities(
 	struct isl_constraint **lower,
 	struct isl_constraint **upper);
 
-__isl_export
 __isl_give isl_space *isl_constraint_get_space(
 	__isl_keep isl_constraint *constraint);
-__isl_export
 __isl_give isl_local_space *isl_constraint_get_local_space(
 	__isl_keep isl_constraint *constraint);
 int isl_constraint_dim(__isl_keep isl_constraint *constraint,
@@ -98,14 +90,12 @@ isl_bool isl_constraint_involves_dims(__isl_keep isl_constraint *constraint,
 
 const char *isl_constraint_get_dim_name(__isl_keep isl_constraint *constraint,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_val *isl_constraint_get_constant_val(
 	__isl_keep isl_constraint *constraint);
 __isl_give isl_val *isl_constraint_get_coefficient_val(
 	__isl_keep isl_constraint *constraint, enum isl_dim_type type, int pos);
 __isl_give isl_constraint *isl_constraint_set_constant_si(
 	__isl_take isl_constraint *constraint, int v);
-__isl_export
 __isl_give isl_constraint *isl_constraint_set_constant_val(
 	__isl_take isl_constraint *constraint, __isl_take isl_val *v);
 __isl_give isl_constraint *isl_constraint_set_coefficient_si(
@@ -115,15 +105,12 @@ __isl_give isl_constraint *isl_constraint_set_coefficient_val(
 	__isl_take isl_constraint *constraint,
 	enum isl_dim_type type, int pos, __isl_take isl_val *v);
 
-__isl_export
 __isl_give isl_aff *isl_constraint_get_div(__isl_keep isl_constraint *constraint,
 	int pos);
 
 struct isl_constraint *isl_constraint_negate(struct isl_constraint *constraint);
 
-__isl_export
 isl_bool isl_constraint_is_equality(__isl_keep isl_constraint *constraint);
-__isl_export
 int isl_constraint_is_div_constraint(__isl_keep isl_constraint *constraint);
 
 isl_bool isl_constraint_is_lower_bound(__isl_keep isl_constraint *constraint,
@@ -138,16 +125,13 @@ __isl_give isl_basic_set *isl_basic_set_from_constraint(
 
 __isl_give isl_aff *isl_constraint_get_bound(
 	__isl_keep isl_constraint *constraint, enum isl_dim_type type, int pos);
-__isl_export
 __isl_give isl_aff *isl_constraint_get_aff(
 	__isl_keep isl_constraint *constraint);
 __isl_give isl_constraint *isl_equality_from_aff(__isl_take isl_aff *aff);
 __isl_give isl_constraint *isl_inequality_from_aff(__isl_take isl_aff *aff);
 
-__isl_export
 int isl_constraint_plain_cmp(__isl_keep isl_constraint *c1,
 	__isl_keep isl_constraint *c2);
-__isl_export
 int isl_constraint_cmp_last_non_zero(__isl_keep isl_constraint *c1,
 	__isl_keep isl_constraint *c2);
 

--- a/include/isl/ilp.h
+++ b/include/isl/ilp.h
@@ -20,7 +20,6 @@
 extern "C" {
 #endif
 
-__isl_export
 __isl_give isl_val *isl_basic_set_max_val(__isl_keep isl_basic_set *bset,
 	__isl_keep isl_aff *obj);
 __isl_export

--- a/include/isl/local_space.h
+++ b/include/isl/local_space.h
@@ -23,9 +23,7 @@ __isl_give isl_local_space *isl_local_space_copy(
 __isl_null isl_local_space *isl_local_space_free(
 	__isl_take isl_local_space *ls);
 
-__isl_export
 isl_bool isl_local_space_is_params(__isl_keep isl_local_space *ls);
-__isl_export
 isl_bool isl_local_space_is_set(__isl_keep isl_local_space *ls);
 
 __isl_give isl_local_space *isl_local_space_set_tuple_id(
@@ -48,22 +46,17 @@ __isl_give isl_id *isl_local_space_get_dim_id(__isl_keep isl_local_space *ls,
 __isl_give isl_local_space *isl_local_space_set_dim_id(
 	__isl_take isl_local_space *ls,
 	enum isl_dim_type type, unsigned pos, __isl_take isl_id *id);
-__isl_export
 __isl_give isl_space *isl_local_space_get_space(__isl_keep isl_local_space *ls);
-__isl_export
 __isl_give isl_aff *isl_local_space_get_div(__isl_keep isl_local_space *ls,
 	int pos);
 
 int isl_local_space_find_dim_by_name(__isl_keep isl_local_space *ls,
 	enum isl_dim_type type, const char *name);
 
-__isl_export
 __isl_give isl_local_space *isl_local_space_domain(
 	__isl_take isl_local_space *ls);
-__isl_export
 __isl_give isl_local_space *isl_local_space_range(
 	__isl_take isl_local_space *ls);
-__isl_export
 __isl_give isl_local_space *isl_local_space_from_domain(
 	__isl_take isl_local_space *ls);
 __isl_give isl_local_space *isl_local_space_add_dims(
@@ -77,27 +70,21 @@ __isl_give isl_local_space *isl_local_space_insert_dims(
 __isl_give isl_local_space *isl_local_space_set_from_params(
 	__isl_take isl_local_space *ls);
 
-__isl_export
 __isl_give isl_local_space *isl_local_space_intersect(
 	__isl_take isl_local_space *ls1, __isl_take isl_local_space *ls2);
 
-__isl_export
 __isl_give isl_local_space *isl_local_space_wrap(
 	__isl_take isl_local_space *ls);
 
 __isl_export
-__isl_export
 isl_bool isl_local_space_is_equal(__isl_keep isl_local_space *ls1,
 	__isl_keep isl_local_space *ls2);
 
-__isl_export
 __isl_give isl_basic_map *isl_local_space_lifting(
 	__isl_take isl_local_space *ls);
 
-__isl_export
 __isl_give isl_local_space *isl_local_space_flatten_domain(
 	__isl_take isl_local_space *ls);
-__isl_export
 __isl_give isl_local_space *isl_local_space_flatten_range(
 	__isl_take isl_local_space *ls);
 

--- a/include/isl/map.h
+++ b/include/isl/map.h
@@ -52,7 +52,6 @@ unsigned isl_map_dim(__isl_keep isl_map *map, enum isl_dim_type type);
 
 isl_ctx *isl_basic_map_get_ctx(__isl_keep isl_basic_map *bmap);
 isl_ctx *isl_map_get_ctx(__isl_keep isl_map *map);
-__isl_export
 __isl_give isl_space *isl_basic_map_get_space(__isl_keep isl_basic_map *bmap);
 __isl_export
 __isl_give isl_space *isl_map_get_space(__isl_keep isl_map *map);
@@ -131,14 +130,12 @@ __isl_give isl_basic_map *isl_basic_map_less_at(__isl_take isl_space *dim,
 	unsigned pos);
 __isl_give isl_basic_map *isl_basic_map_more_at(__isl_take isl_space *dim,
 	unsigned pos);
-__isl_export
 __isl_give isl_basic_map *isl_basic_map_empty(__isl_take isl_space *space);
 __isl_give isl_basic_map *isl_basic_map_universe(__isl_take isl_space *space);
 __isl_give isl_basic_map *isl_basic_map_nat_universe(__isl_take isl_space *dim);
 __isl_give isl_basic_map *isl_basic_map_remove_redundancies(
 	__isl_take isl_basic_map *bmap);
 __isl_give isl_map *isl_map_remove_redundancies(__isl_take isl_map *map);
-__isl_export
 __isl_give isl_basic_map *isl_map_simple_hull(__isl_take isl_map *map);
 __isl_export
 __isl_give isl_basic_map *isl_map_unshifted_simple_hull(
@@ -160,7 +157,6 @@ __isl_export
 __isl_give isl_basic_map *isl_basic_map_intersect(
 		__isl_take isl_basic_map *bmap1,
 		__isl_take isl_basic_map *bmap2);
-__isl_export
 __isl_give isl_basic_map *isl_basic_map_list_intersect(
 	__isl_take isl_basic_map_list *list);
 __isl_export
@@ -184,7 +180,6 @@ __isl_give isl_basic_map *isl_basic_map_preimage_range_multi_aff(
 	__isl_take isl_basic_map *bmap, __isl_take isl_multi_aff *ma);
 __isl_export
 __isl_give isl_basic_map *isl_basic_map_reverse(__isl_take isl_basic_map *bmap);
-__isl_export
 __isl_give isl_basic_set *isl_basic_map_domain(__isl_take isl_basic_map *bmap);
 __isl_give isl_basic_set *isl_basic_map_range(__isl_take isl_basic_map *bmap);
 __isl_give isl_basic_map *isl_basic_map_domain_map(
@@ -303,7 +298,6 @@ __isl_give isl_map *isl_map_universe(__isl_take isl_space *space);
 __isl_give isl_map *isl_map_nat_universe(__isl_take isl_space *dim);
 __isl_export
 __isl_give isl_map *isl_map_empty(__isl_take isl_space *space);
-__isl_export
 __isl_give isl_map *isl_map_identity(__isl_take isl_space *dim);
 __isl_give isl_map *isl_map_lex_lt_first(__isl_take isl_space *dim, unsigned n);
 __isl_give isl_map *isl_map_lex_le_first(__isl_take isl_space *dim, unsigned n);
@@ -350,7 +344,6 @@ __isl_give isl_map *isl_map_apply_range(
 __isl_overload
 __isl_give isl_map *isl_map_preimage_domain_multi_aff(__isl_take isl_map *map,
 	__isl_take isl_multi_aff *ma);
-__isl_overload
 __isl_give isl_map *isl_map_preimage_range_multi_aff(__isl_take isl_map *map,
 	__isl_take isl_multi_aff *ma);
 __isl_give isl_map *isl_map_preimage_domain_pw_multi_aff(
@@ -367,10 +360,8 @@ __isl_give isl_basic_map *isl_basic_map_domain_product(
 	__isl_take isl_basic_map *bmap1, __isl_take isl_basic_map *bmap2);
 __isl_give isl_basic_map *isl_basic_map_range_product(
 	__isl_take isl_basic_map *bmap1, __isl_take isl_basic_map *bmap2);
-__isl_export
 __isl_give isl_map *isl_map_domain_product(__isl_take isl_map *map1,
 	__isl_take isl_map *map2);
-__isl_export
 __isl_give isl_map *isl_map_range_product(__isl_take isl_map *map1,
 	__isl_take isl_map *map2);
 __isl_give isl_basic_map *isl_basic_map_flat_product(
@@ -390,11 +381,8 @@ __isl_give isl_map *isl_map_factor_domain(__isl_take isl_map *map);
 __isl_give isl_map *isl_map_factor_range(__isl_take isl_map *map);
 __isl_export
 __isl_give isl_map *isl_map_domain_factor_domain(__isl_take isl_map *map);
-__isl_export
 __isl_give isl_map *isl_map_domain_factor_range(__isl_take isl_map *map);
-__isl_export
 __isl_give isl_map *isl_map_range_factor_domain(__isl_take isl_map *map);
-__isl_export
 __isl_give isl_map *isl_map_range_factor_range(__isl_take isl_map *map);
 __isl_export
 __isl_give isl_map *isl_map_intersect(__isl_take isl_map *map1,
@@ -499,11 +487,9 @@ __isl_export
 isl_bool isl_basic_set_is_wrapping(__isl_keep isl_basic_set *bset);
 __isl_export
 isl_bool isl_set_is_wrapping(__isl_keep isl_set *set);
-__isl_export
 __isl_give isl_basic_set *isl_basic_map_wrap(__isl_take isl_basic_map *bmap);
 __isl_export
 __isl_give isl_set *isl_map_wrap(__isl_take isl_map *map);
-__isl_export
 __isl_give isl_basic_map *isl_basic_set_unwrap(__isl_take isl_basic_set *bset);
 __isl_export
 __isl_give isl_map *isl_set_unwrap(__isl_take isl_set *set);
@@ -525,36 +511,25 @@ __isl_export
 __isl_give isl_basic_set *isl_basic_set_flatten(__isl_take isl_basic_set *bset);
 __isl_export
 __isl_give isl_set *isl_set_flatten(__isl_take isl_set *set);
-__isl_export
 __isl_give isl_map *isl_set_flatten_map(__isl_take isl_set *set);
-__isl_export
 __isl_give isl_set *isl_map_params(__isl_take isl_map *map);
 __isl_export
 __isl_give isl_set *isl_map_domain(__isl_take isl_map *bmap);
 __isl_export
 __isl_give isl_set *isl_map_range(__isl_take isl_map *map);
-__isl_export
 __isl_give isl_map *isl_map_domain_map(__isl_take isl_map *map);
-__isl_export
 __isl_give isl_map *isl_map_range_map(__isl_take isl_map *map);
-__isl_export
 __isl_give isl_map *isl_set_wrapped_domain_map(__isl_take isl_set *set);
 __isl_constructor
 __isl_give isl_map *isl_map_from_basic_map(__isl_take isl_basic_map *bmap);
-__isl_export
 __isl_give isl_map *isl_map_from_domain(__isl_take isl_set *set);
-__isl_export
 __isl_give isl_basic_map *isl_basic_map_from_domain(
 	__isl_take isl_basic_set *bset);
-__isl_export
 __isl_give isl_basic_map *isl_basic_map_from_range(
 	__isl_take isl_basic_set *bset);
-__isl_export
 __isl_give isl_map *isl_map_from_range(__isl_take isl_set *set);
-__isl_constructor
 __isl_give isl_basic_map *isl_basic_map_from_domain_and_range(
 	__isl_take isl_basic_set *domain, __isl_take isl_basic_set *range);
-__isl_constructor
 __isl_give isl_map *isl_map_from_domain_and_range(__isl_take isl_set *domain,
 	__isl_take isl_set *range);
 __isl_export
@@ -594,32 +569,23 @@ __isl_give isl_basic_map *isl_basic_map_zip(__isl_take isl_basic_map *bmap);
 __isl_export
 __isl_give isl_map *isl_map_zip(__isl_take isl_map *map);
 
-__isl_export
 isl_bool isl_basic_map_can_curry(__isl_keep isl_basic_map *bmap);
-__isl_export
 isl_bool isl_map_can_curry(__isl_keep isl_map *map);
-__isl_export
 __isl_give isl_basic_map *isl_basic_map_curry(__isl_take isl_basic_map *bmap);
 __isl_export
 __isl_give isl_map *isl_map_curry(__isl_take isl_map *map);
 
-__isl_export
 isl_bool isl_map_can_range_curry(__isl_keep isl_map *map);
-__isl_export
 __isl_give isl_map *isl_map_range_curry(__isl_take isl_map *map);
 
-__isl_export
 isl_bool isl_basic_map_can_uncurry(__isl_keep isl_basic_map *bmap);
-__isl_export
 isl_bool isl_map_can_uncurry(__isl_keep isl_map *map);
-__isl_export
 __isl_give isl_basic_map *isl_basic_map_uncurry(__isl_take isl_basic_map *bmap);
 __isl_export
 __isl_give isl_map *isl_map_uncurry(__isl_take isl_map *map);
 
 __isl_give isl_map *isl_map_make_disjoint(__isl_take isl_map *map);
 __isl_give isl_map *isl_basic_map_compute_divs(__isl_take isl_basic_map *bmap);
-__isl_export
 __isl_give isl_map *isl_map_compute_divs(__isl_take isl_map *map);
 ISL_DEPRECATED
 __isl_give isl_map *isl_map_align_divs(__isl_take isl_map *map);
@@ -682,12 +648,10 @@ isl_bool isl_map_plain_is_equal(__isl_keep isl_map *map1,
 
 uint32_t isl_map_get_hash(__isl_keep isl_map *map);
 
-__isl_export
 int isl_map_n_basic_map(__isl_keep isl_map *map);
 __isl_export
 isl_stat isl_map_foreach_basic_map(__isl_keep isl_map *map,
 	isl_stat (*fn)(__isl_take isl_basic_map *bmap, void *user), void *user);
-__isl_export
 __isl_give isl_basic_map_list *isl_map_get_basic_map_list(
 	__isl_keep isl_map *map);
 
@@ -730,15 +694,12 @@ __isl_give isl_basic_map *isl_basic_map_from_constraint_matrices(
 	enum isl_dim_type c2, enum isl_dim_type c3,
 	enum isl_dim_type c4, enum isl_dim_type c5);
 
-__isl_constructor
 __isl_give isl_basic_map *isl_basic_map_from_aff(__isl_take isl_aff *aff);
-__isl_constructor
 __isl_give isl_basic_map *isl_basic_map_from_multi_aff(
 	__isl_take isl_multi_aff *maff);
 __isl_give isl_basic_map *isl_basic_map_from_aff_list(
 	__isl_take isl_space *domain_space, __isl_take isl_aff_list *list);
 
-__isl_constructor
 __isl_give isl_map *isl_map_from_aff(__isl_take isl_aff *aff);
 __isl_constructor
 __isl_give isl_map *isl_map_from_multi_aff(__isl_take isl_multi_aff *maff);
@@ -746,7 +707,7 @@ __isl_give isl_map *isl_map_from_multi_aff(__isl_take isl_multi_aff *maff);
 __isl_give isl_pw_aff *isl_map_dim_min(__isl_take isl_map *map, int pos);
 __isl_give isl_pw_aff *isl_map_dim_max(__isl_take isl_map *map, int pos);
 
-ISL_DECLARE_EXPORTED_LIST_FN(basic_map)
+ISL_DECLARE_LIST_FN(basic_map)
 ISL_DECLARE_EXPORTED_LIST_FN(map)
 
 #if defined(__cplusplus)

--- a/include/isl/map_type.h
+++ b/include/isl/map_type.h
@@ -10,7 +10,7 @@ extern "C" {
 
 struct __isl_subclass(isl_map) isl_basic_map;
 typedef struct isl_basic_map isl_basic_map;
-ISL_DECLARE_EXPORTED_LIST_TYPE(basic_map)
+ISL_DECLARE_LIST_TYPE(basic_map)
 struct __isl_subclass(isl_union_map) isl_map;
 typedef struct isl_map isl_map;
 ISL_DECLARE_EXPORTED_LIST_TYPE(map)
@@ -18,7 +18,7 @@ ISL_DECLARE_EXPORTED_LIST_TYPE(map)
 #ifndef isl_basic_set
 struct __isl_subclass(isl_set) isl_basic_set;
 typedef struct isl_basic_set isl_basic_set;
-ISL_DECLARE_EXPORTED_LIST_TYPE(basic_set)
+ISL_DECLARE_LIST_TYPE(basic_set)
 #endif
 
 #ifndef isl_set
@@ -27,7 +27,7 @@ typedef struct isl_set isl_set;
 ISL_DECLARE_EXPORTED_LIST_TYPE(set)
 #endif
 
-ISL_DECLARE_EXPORTED_LIST_FN(basic_set)
+ISL_DECLARE_LIST_FN(basic_set)
 ISL_DECLARE_EXPORTED_LIST_FN(set)
 
 #if defined(__cplusplus)

--- a/include/isl/multi.h
+++ b/include/isl/multi.h
@@ -16,7 +16,6 @@ isl_ctx *isl_multi_##BASE##_get_ctx(					\
 __isl_export								\
 __isl_give isl_space *isl_multi_##BASE##_get_space(			\
 	__isl_keep isl_multi_##BASE *multi);				\
-__isl_export								\
 __isl_give isl_space *isl_multi_##BASE##_get_domain_space(		\
 	__isl_keep isl_multi_##BASE *multi);				\
 __isl_constructor							\
@@ -31,7 +30,6 @@ __isl_null isl_multi_##BASE *isl_multi_##BASE##_free(			\
 isl_bool isl_multi_##BASE##_plain_is_equal(				\
 	__isl_keep isl_multi_##BASE *multi1,				\
 	__isl_keep isl_multi_##BASE *multi2);				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_reset_user(		\
 	__isl_take isl_multi_##BASE *multi);				\
 __isl_export                                                            \
@@ -46,11 +44,9 @@ __isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_set_##BASE(		\
 	__isl_take isl_multi_##BASE *multi, int pos,			\
 	__isl_take isl_##BASE *el);					\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_range_splice(		\
 	__isl_take isl_multi_##BASE *multi1, unsigned pos,		\
 	__isl_take isl_multi_##BASE *multi2);				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_flatten_range(		\
 	__isl_take isl_multi_##BASE *multi);				\
 __isl_export								\
@@ -61,25 +57,19 @@ __isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_range_product(		\
 	__isl_take isl_multi_##BASE *multi1,				\
 	__isl_take isl_multi_##BASE *multi2);				\
-__isl_export                                                            \
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_factor_domain(		\
 	__isl_take isl_multi_##BASE *multi);				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_factor_range(		\
 	__isl_take isl_multi_##BASE *multi);				\
 isl_bool isl_multi_##BASE##_range_is_wrapping(				\
 	__isl_keep isl_multi_##BASE *multi);				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_range_factor_domain(	\
 	__isl_take isl_multi_##BASE *multi);				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_range_factor_range(	\
 	__isl_take isl_multi_##BASE *multi);				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_align_params(		\
 	__isl_take isl_multi_##BASE *multi,				\
 	__isl_take isl_space *model);					\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_from_range(		\
 	__isl_take isl_multi_##BASE *multi);
 
@@ -106,7 +96,6 @@ __isl_overload								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_mod_multi_val(		\
 	__isl_take isl_multi_##BASE *multi,				\
 	__isl_take isl_multi_val *mv);					\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_add(			\
 	__isl_take isl_multi_##BASE *multi1,				\
 	__isl_take isl_multi_##BASE *multi2);				\
@@ -188,11 +177,9 @@ __isl_give isl_multi_##BASE *isl_multi_##BASE##_reset_tuple_id(		\
 	__isl_take isl_multi_##BASE *multi, enum isl_dim_type type);
 
 #define ISL_DECLARE_MULTI_WITH_DOMAIN(BASE)				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_product(		\
 	__isl_take isl_multi_##BASE *multi1,				\
 	__isl_take isl_multi_##BASE *multi2);				\
-__isl_export								\
 __isl_give isl_multi_##BASE *isl_multi_##BASE##_splice(			\
 	__isl_take isl_multi_##BASE *multi1, unsigned in_pos,		\
 	unsigned out_pos, __isl_take isl_multi_##BASE *multi2);

--- a/include/isl/point.h
+++ b/include/isl/point.h
@@ -9,14 +9,12 @@
 extern "C" {
 #endif
 
-struct __isl_export __isl_subclass(isl_basic_set) isl_point;
+struct __isl_subclass(isl_basic_set) isl_point;
 typedef struct isl_point isl_point;
 
 isl_ctx *isl_point_get_ctx(__isl_keep isl_point *pnt);
-__isl_export
 __isl_give isl_space *isl_point_get_space(__isl_keep isl_point *pnt);
 
-__isl_constructor
 __isl_give isl_point *isl_point_zero(__isl_take isl_space *dim);
 __isl_give isl_point *isl_point_copy(__isl_keep isl_point *pnt);
 __isl_null isl_point *isl_point_free(__isl_take isl_point *pnt);
@@ -32,7 +30,6 @@ __isl_give isl_point *isl_point_sub_ui(__isl_take isl_point *pnt,
 	enum isl_dim_type type, int pos, unsigned val);
 
 __isl_give isl_point *isl_point_void(__isl_take isl_space *dim);
-__isl_export
 isl_bool isl_point_is_void(__isl_keep isl_point *pnt);
 
 __isl_give isl_printer *isl_printer_print_point(

--- a/include/isl/schedule.h
+++ b/include/isl/schedule.h
@@ -172,7 +172,6 @@ __isl_export
 __isl_give isl_union_map *isl_schedule_get_map(__isl_keep isl_schedule *sched);
 
 isl_ctx *isl_schedule_get_ctx(__isl_keep isl_schedule *sched);
-__isl_export
 isl_bool isl_schedule_plain_is_equal(__isl_keep isl_schedule *schedule1,
 	__isl_keep isl_schedule *schedule2);
 
@@ -203,7 +202,6 @@ __isl_give isl_schedule *isl_schedule_insert_guard(
 __isl_export
 __isl_give isl_schedule *isl_schedule_sequence(
 	__isl_take isl_schedule *schedule1, __isl_take isl_schedule *schedule2);
-__isl_export
 __isl_give isl_schedule *isl_schedule_set(
 	__isl_take isl_schedule *schedule1, __isl_take isl_schedule *schedule2);
 __isl_give isl_schedule *isl_schedule_intersect_domain(
@@ -211,7 +209,6 @@ __isl_give isl_schedule *isl_schedule_intersect_domain(
 __isl_give isl_schedule *isl_schedule_gist_domain_params(
 	__isl_take isl_schedule *schedule, __isl_take isl_set *context);
 
-__isl_export
 __isl_give isl_schedule *isl_schedule_reset_user(
 	__isl_take isl_schedule *schedule);
 __isl_give isl_schedule *isl_schedule_align_params(

--- a/include/isl/schedule_node.h
+++ b/include/isl/schedule_node.h
@@ -58,32 +58,23 @@ __isl_give isl_schedule_node *isl_schedule_node_map_descendant_bottom_up(
 
 __isl_export
 int isl_schedule_node_get_tree_depth(__isl_keep isl_schedule_node *node);
-__isl_export
 isl_bool isl_schedule_node_has_parent(__isl_keep isl_schedule_node *node);
-__isl_export
 isl_bool isl_schedule_node_has_children(__isl_keep isl_schedule_node *node);
-__isl_export
 isl_bool isl_schedule_node_has_previous_sibling(
 	__isl_keep isl_schedule_node *node);
-__isl_export
 isl_bool isl_schedule_node_has_next_sibling(__isl_keep isl_schedule_node *node);
 __isl_export
 int isl_schedule_node_n_children(__isl_keep isl_schedule_node *node);
-__isl_export
 int isl_schedule_node_get_child_position(__isl_keep isl_schedule_node *node);
-__isl_export
 int isl_schedule_node_get_ancestor_child_position(
 	__isl_keep isl_schedule_node *node,
 	__isl_keep isl_schedule_node *ancestor);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_get_child(
 	__isl_keep isl_schedule_node *node, int pos);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_get_shared_ancestor(
 	__isl_keep isl_schedule_node *node1,
 	__isl_keep isl_schedule_node *node2);
 
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_root(
 	__isl_take isl_schedule_node *node);
 __isl_export
@@ -95,17 +86,13 @@ __isl_give isl_schedule_node *isl_schedule_node_ancestor(
 __isl_export
 __isl_give isl_schedule_node *isl_schedule_node_child(
 	__isl_take isl_schedule_node *node, int pos);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_first_child(
 	__isl_take isl_schedule_node *node);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_previous_sibling(
 	__isl_take isl_schedule_node *node);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_next_sibling(
 	__isl_take isl_schedule_node *node);
 
-__isl_export
 isl_bool isl_schedule_node_is_subtree_anchored(
 	__isl_keep isl_schedule_node *node);
 
@@ -118,13 +105,11 @@ isl_schedule_node_sequence_get_partial_schedule_multi_union_pw_aff(
 __isl_give isl_schedule_node *isl_schedule_node_sequence_splice_child(
 	__isl_take isl_schedule_node *node, int pos);
 
-__isl_export
 __isl_give isl_space *isl_schedule_node_band_get_space(
 	__isl_keep isl_schedule_node *node);
 __isl_export
 __isl_give isl_multi_union_pw_aff *isl_schedule_node_band_get_partial_schedule(
 	__isl_keep isl_schedule_node *node);
-__isl_export
 __isl_give isl_union_map *isl_schedule_node_band_get_partial_schedule_union_map(
 	__isl_keep isl_schedule_node *node);
 enum isl_ast_loop_type isl_schedule_node_band_member_get_ast_loop_type(
@@ -136,17 +121,13 @@ __isl_give isl_schedule_node *isl_schedule_node_band_member_set_ast_loop_type(
 enum isl_ast_loop_type isl_schedule_node_band_member_get_isolate_ast_loop_type(
 	__isl_keep isl_schedule_node *node, int pos);
 __isl_give isl_schedule_node *
-__isl_export
 isl_schedule_node_band_member_set_isolate_ast_loop_type(
 	__isl_take isl_schedule_node *node, int pos,
 	enum isl_ast_loop_type type);
-__isl_export
 __isl_give isl_union_set *isl_schedule_node_band_get_ast_build_options(
 	__isl_keep isl_schedule_node *node);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_band_set_ast_build_options(
 	__isl_take isl_schedule_node *node, __isl_take isl_union_set *options);
-__isl_export
 __isl_give isl_set *isl_schedule_node_band_get_ast_isolate_option(
 	__isl_keep isl_schedule_node *node);
 __isl_export
@@ -169,16 +150,12 @@ int isl_options_get_tile_scale_tile_loops(isl_ctx *ctx);
 isl_stat isl_options_set_tile_shift_point_loops(isl_ctx *ctx, int val);
 int isl_options_get_tile_shift_point_loops(isl_ctx *ctx);
 
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_band_scale(
 	__isl_take isl_schedule_node *node, __isl_take isl_multi_val *mv);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_band_scale_down(
 	__isl_take isl_schedule_node *node, __isl_take isl_multi_val *mv);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_band_mod(
 	__isl_take isl_schedule_node *node, __isl_take isl_multi_val *mv);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_band_shift(
 	__isl_take isl_schedule_node *node,
 	__isl_take isl_multi_union_pw_aff *shift);
@@ -189,7 +166,6 @@ __isl_give isl_schedule_node *isl_schedule_node_band_lower(
 	__isl_take isl_schedule_node *node);
 __isl_give isl_schedule_node *isl_schedule_node_band_sink(
 	__isl_take isl_schedule_node *node);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_band_split(
 	__isl_take isl_schedule_node *node, int pos);
 __isl_give isl_schedule_node *isl_schedule_node_band_join_child(
@@ -204,7 +180,6 @@ __isl_give isl_union_set *isl_schedule_node_domain_get_domain(
 __isl_export
 __isl_give isl_union_map *isl_schedule_node_expansion_get_expansion(
 	__isl_keep isl_schedule_node *node);
-__isl_export
 __isl_give isl_union_pw_multi_aff *isl_schedule_node_expansion_get_contraction(
 	__isl_keep isl_schedule_node *node);
 __isl_export
@@ -213,16 +188,12 @@ __isl_give isl_union_map *isl_schedule_node_extension_get_extension(
 __isl_export
 __isl_give isl_union_set *isl_schedule_node_filter_get_filter(
 	__isl_keep isl_schedule_node *node);
-__isl_export
 __isl_give isl_set *isl_schedule_node_guard_get_guard(
 	__isl_keep isl_schedule_node *node);
-__isl_export
 __isl_give isl_id *isl_schedule_node_mark_get_id(
 	__isl_keep isl_schedule_node *node);
 
-__isl_export
 int isl_schedule_node_get_schedule_depth(__isl_keep isl_schedule_node *node);
-__isl_export
 __isl_give isl_union_set *isl_schedule_node_get_domain(
 	__isl_keep isl_schedule_node *node);
 __isl_export
@@ -239,7 +210,6 @@ isl_schedule_node_get_prefix_schedule_union_pw_multi_aff(
 __isl_export
 __isl_give isl_union_map *isl_schedule_node_get_prefix_schedule_union_map(
 	__isl_keep isl_schedule_node *node);
-__isl_export
 __isl_give isl_union_map *isl_schedule_node_get_prefix_schedule_relation(
 	__isl_keep isl_schedule_node *node);
 __isl_give isl_union_map *isl_schedule_node_get_subtree_schedule_union_map(
@@ -259,10 +229,8 @@ __isl_give isl_schedule_node *isl_schedule_node_insert_partial_schedule(
 __isl_export
 __isl_give isl_schedule_node *isl_schedule_node_insert_filter(
 	__isl_take isl_schedule_node *node, __isl_take isl_union_set *filter);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_insert_guard(
 	__isl_take isl_schedule_node *node, __isl_take isl_set *context);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_insert_mark(
 	__isl_take isl_schedule_node *node, __isl_take isl_id *mark);
 __isl_export
@@ -274,17 +242,13 @@ __isl_give isl_schedule_node *isl_schedule_node_insert_set(
 	__isl_take isl_schedule_node *node,
 	__isl_take isl_union_set_list *filters);
 
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_cut(
 	__isl_take isl_schedule_node *node);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_delete(
 	__isl_take isl_schedule_node *node);
 
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_order_before(
 	__isl_take isl_schedule_node *node, __isl_take isl_union_set *filter);
-__isl_export
 __isl_give isl_schedule_node *isl_schedule_node_order_after(
 	__isl_take isl_schedule_node *node, __isl_take isl_union_set *filter);
 

--- a/include/isl/set.h
+++ b/include/isl/set.h
@@ -25,23 +25,18 @@
 extern "C" {
 #endif
 
-__isl_export
 unsigned isl_basic_set_n_dim(__isl_keep isl_basic_set *bset);
-__isl_export
 unsigned isl_basic_set_n_param(__isl_keep isl_basic_set *bset);
 unsigned isl_basic_set_total_dim(__isl_keep const isl_basic_set *bset);
 unsigned isl_basic_set_dim(__isl_keep isl_basic_set *bset,
 				enum isl_dim_type type);
 
-__isl_export
 unsigned isl_set_n_dim(__isl_keep isl_set *set);
-__isl_export
 unsigned isl_set_n_param(__isl_keep isl_set *set);
 unsigned isl_set_dim(__isl_keep isl_set *set, enum isl_dim_type type);
 
 isl_ctx *isl_basic_set_get_ctx(__isl_keep isl_basic_set *bset);
 isl_ctx *isl_set_get_ctx(__isl_keep isl_set *set);
-__isl_export
 __isl_give isl_space *isl_basic_set_get_space(__isl_keep isl_basic_set *bset);
 __isl_export
 __isl_give isl_space *isl_set_get_space(__isl_keep isl_set *set);
@@ -61,7 +56,6 @@ __isl_export
 const char *isl_set_get_tuple_name(__isl_keep isl_set *set);
 __isl_give isl_basic_set *isl_basic_set_set_tuple_name(
 	__isl_take isl_basic_set *set, const char *s);
-__isl_export
 __isl_give isl_set *isl_set_set_tuple_name(__isl_take isl_set *set,
 	const char *s);
 const char *isl_basic_set_get_dim_name(__isl_keep isl_basic_set *bset,
@@ -78,7 +72,6 @@ __isl_give isl_set *isl_set_set_dim_name(__isl_take isl_set *set,
 
 __isl_give isl_id *isl_basic_set_get_dim_id(__isl_keep isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos);
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_set_tuple_id(
 	__isl_take isl_basic_set *bset, __isl_take isl_id *id);
 __isl_give isl_set *isl_set_set_dim_id(__isl_take isl_set *set,
@@ -90,9 +83,7 @@ __isl_give isl_id *isl_set_get_dim_id(__isl_keep isl_set *set,
 __isl_export
 __isl_give isl_set *isl_set_set_tuple_id(__isl_take isl_set *set,
 	__isl_take isl_id *id);
-__isl_export
 __isl_give isl_set *isl_set_reset_tuple_id(__isl_take isl_set *set);
-__isl_export
 isl_bool isl_set_has_tuple_id(__isl_keep isl_set *set);
 __isl_export
 __isl_give isl_id *isl_set_get_tuple_id(__isl_keep isl_set *set);
@@ -108,9 +99,7 @@ int isl_basic_set_is_rational(__isl_keep isl_basic_set *bset);
 __isl_null isl_basic_set *isl_basic_set_free(__isl_take isl_basic_set *bset);
 __isl_give isl_basic_set *isl_basic_set_copy(__isl_keep isl_basic_set *bset);
 __isl_give isl_basic_set *isl_basic_set_empty(__isl_take isl_space *space);
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_universe(__isl_take isl_space *space);
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_nat_universe(__isl_take isl_space *dim);
 __isl_give isl_basic_set *isl_basic_set_positive_orthant(
 	__isl_take isl_space *space);
@@ -233,9 +222,7 @@ int isl_basic_set_compare_at(struct isl_basic_set *bset1,
 int isl_set_follows_at(__isl_keep isl_set *set1,
 	__isl_keep isl_set *set2, int pos);
 
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_params(__isl_take isl_basic_set *bset);
-__isl_export
 __isl_give isl_basic_set *isl_basic_set_from_params(
 	__isl_take isl_basic_set *bset);
 __isl_export
@@ -253,9 +240,7 @@ __isl_give isl_map *isl_set_unbind_params_insert_domain(
 isl_stat isl_basic_set_dims_get_sign(__isl_keep isl_basic_set *bset,
 	enum isl_dim_type type, unsigned pos, unsigned n, int *signs);
 
-__isl_export
 isl_bool isl_basic_set_plain_is_universe(__isl_keep isl_basic_set *bset);
-__isl_export
 isl_bool isl_basic_set_is_universe(__isl_keep isl_basic_set *bset);
 isl_bool isl_basic_set_plain_is_empty(__isl_keep isl_basic_set *bset);
 __isl_export
@@ -331,7 +316,6 @@ __isl_export
 __isl_give isl_set *isl_set_apply(
 		__isl_take isl_set *set,
 		__isl_take isl_map *map);
-__isl_export
 __isl_give isl_set *isl_set_preimage_multi_aff(__isl_take isl_set *set,
 	__isl_take isl_multi_aff *ma);
 __isl_give isl_set *isl_set_preimage_pw_multi_aff(__isl_take isl_set *set,
@@ -426,7 +410,6 @@ isl_bool isl_set_is_equal(__isl_keep isl_set *set1, __isl_keep isl_set *set2);
 __isl_export
 isl_bool isl_set_is_disjoint(__isl_keep isl_set *set1,
 	__isl_keep isl_set *set2);
-__isl_export
 isl_bool isl_set_is_singleton(__isl_keep isl_set *set);
 isl_bool isl_set_is_box(__isl_keep isl_set *set);
 isl_bool isl_set_has_equal_space(__isl_keep isl_set *set1,
@@ -438,9 +421,7 @@ __isl_give isl_basic_set *isl_basic_set_neg(__isl_take isl_basic_set *bset);
 __isl_give isl_set *isl_set_neg(__isl_take isl_set *set);
 
 __isl_give isl_set *isl_set_make_disjoint(__isl_take isl_set *set);
-__isl_export
 __isl_give isl_set *isl_basic_set_compute_divs(__isl_take isl_basic_set *bset);
-__isl_export
 __isl_give isl_set *isl_set_compute_divs(__isl_take isl_set *set);
 ISL_DEPRECATED
 __isl_give isl_set *isl_set_align_divs(__isl_take isl_set *set);
@@ -492,7 +473,6 @@ int isl_set_n_basic_set(__isl_keep isl_set *set);
 __isl_export
 isl_stat isl_set_foreach_basic_set(__isl_keep isl_set *set,
 	isl_stat (*fn)(__isl_take isl_basic_set *bset, void *user), void *user);
-__isl_export
 __isl_give isl_basic_set_list *isl_set_get_basic_set_list(
 	__isl_keep isl_set *set);
 
@@ -525,7 +505,6 @@ int isl_set_size(__isl_keep isl_set *set);
 
 __isl_give isl_basic_set *isl_basic_set_align_params(
 	__isl_take isl_basic_set *bset, __isl_take isl_space *model);
-__isl_export
 __isl_give isl_set *isl_set_align_params(__isl_take isl_set *set,
 	__isl_take isl_space *model);
 __isl_give isl_basic_set *isl_basic_set_drop_unused_params(

--- a/include/isl/space.h
+++ b/include/isl/space.h
@@ -20,10 +20,8 @@ extern "C" {
 #endif
 
 isl_ctx *isl_space_get_ctx(__isl_keep isl_space *dim);
-__isl_constructor
 __isl_give isl_space *isl_space_alloc(isl_ctx *ctx,
 			unsigned nparam, unsigned n_in, unsigned n_out);
-__isl_constructor
 __isl_give isl_space *isl_space_set_alloc(isl_ctx *ctx,
 			unsigned nparam, unsigned dim);
 __isl_constructor
@@ -31,9 +29,7 @@ __isl_give isl_space *isl_space_params_alloc(isl_ctx *ctx, unsigned nparam);
 __isl_give isl_space *isl_space_copy(__isl_keep isl_space *dim);
 __isl_null isl_space *isl_space_free(__isl_take isl_space *space);
 
-__isl_export
 isl_bool isl_space_is_params(__isl_keep isl_space *space);
-__isl_export
 isl_bool isl_space_is_set(__isl_keep isl_space *space);
 isl_bool isl_space_is_map(__isl_keep isl_space *space);
 
@@ -103,10 +99,8 @@ __isl_give isl_space *isl_space_join(__isl_take isl_space *left,
 __isl_export
 __isl_give isl_space *isl_space_product(__isl_take isl_space *left,
 	__isl_take isl_space *right);
-__isl_export
 __isl_give isl_space *isl_space_domain_product(__isl_take isl_space *left,
 	__isl_take isl_space *right);
-__isl_export
 __isl_give isl_space *isl_space_range_product(__isl_take isl_space *left,
 	__isl_take isl_space *right);
 __isl_give isl_space *isl_space_factor_domain(__isl_take isl_space *space);
@@ -144,15 +138,11 @@ __isl_give isl_space *isl_space_drop_outputs(__isl_take isl_space *dim,
 __isl_give isl_space *isl_space_drop_all_params(__isl_take isl_space *space);
 __isl_export
 __isl_give isl_space *isl_space_domain(__isl_take isl_space *space);
-__isl_export
 __isl_give isl_space *isl_space_from_domain(__isl_take isl_space *space);
 __isl_export
 __isl_give isl_space *isl_space_range(__isl_take isl_space *space);
-__isl_export
 __isl_give isl_space *isl_space_from_range(__isl_take isl_space *space);
-__isl_export
 __isl_give isl_space *isl_space_domain_map(__isl_take isl_space *space);
-__isl_export
 __isl_give isl_space *isl_space_range_map(__isl_take isl_space *space);
 __isl_export
 __isl_give isl_space *isl_space_params(__isl_take isl_space *space);
@@ -165,11 +155,9 @@ __isl_give isl_space *isl_space_add_named_tuple_id_ui(
 __isl_export
 __isl_give isl_space *isl_space_set_from_params(__isl_take isl_space *space);
 
-__isl_export
 __isl_give isl_space *isl_space_align_params(__isl_take isl_space *dim1,
 	__isl_take isl_space *dim2);
 
-__isl_export
 isl_bool isl_space_is_wrapping(__isl_keep isl_space *space);
 isl_bool isl_space_domain_is_wrapping(__isl_keep isl_space *space);
 isl_bool isl_space_range_is_wrapping(__isl_keep isl_space *space);
@@ -182,17 +170,13 @@ __isl_give isl_space *isl_space_unwrap(__isl_take isl_space *dim);
 isl_bool isl_space_can_zip(__isl_keep isl_space *space);
 __isl_give isl_space *isl_space_zip(__isl_take isl_space *dim);
 
-__isl_export
 isl_bool isl_space_can_curry(__isl_keep isl_space *space);
-__isl_export
 __isl_give isl_space *isl_space_curry(__isl_take isl_space *space);
 
 isl_bool isl_space_can_range_curry(__isl_keep isl_space *space);
 __isl_give isl_space *isl_space_range_curry(__isl_take isl_space *space);
 
-__isl_export
 isl_bool isl_space_can_uncurry(__isl_keep isl_space *space);
-__isl_export
 __isl_give isl_space *isl_space_uncurry(__isl_take isl_space *space);
 
 isl_bool isl_space_is_domain(__isl_keep isl_space *space1,
@@ -202,7 +186,6 @@ isl_bool isl_space_is_range(__isl_keep isl_space *space1,
 __isl_export
 isl_bool isl_space_is_equal(__isl_keep isl_space *space1,
 	__isl_keep isl_space *space2);
-__isl_export
 isl_bool isl_space_has_equal_params(__isl_keep isl_space *space1,
 	__isl_keep isl_space *space2);
 __isl_export

--- a/include/isl/union_map.h
+++ b/include/isl/union_map.h
@@ -33,7 +33,6 @@ __isl_give isl_union_map *isl_union_map_copy(__isl_keep isl_union_map *umap);
 __isl_null isl_union_map *isl_union_map_free(__isl_take isl_union_map *umap);
 
 isl_ctx *isl_union_map_get_ctx(__isl_keep isl_union_map *umap);
-__isl_export
 __isl_give isl_space *isl_union_map_get_space(__isl_keep isl_union_map *umap);
 
 __isl_give isl_union_map *isl_union_map_reset_user(
@@ -59,7 +58,6 @@ __isl_give isl_union_pw_multi_aff *isl_union_map_domain_map_union_pw_multi_aff(
 __isl_export
 __isl_give isl_union_map *isl_union_map_range_map(
 	__isl_take isl_union_map *umap);
-__isl_export
 __isl_give isl_union_map *isl_union_set_wrapped_domain_map(
 	__isl_take isl_union_set *uset);
 __isl_export
@@ -178,7 +176,6 @@ __isl_give isl_union_map *isl_union_map_apply_range(
 	__isl_take isl_union_map *umap1, __isl_take isl_union_map *umap2);
 __isl_give isl_union_map *isl_union_map_preimage_domain_multi_aff(
 	__isl_take isl_union_map *umap, __isl_take isl_multi_aff *ma);
-__isl_export
 __isl_give isl_union_map *isl_union_map_preimage_range_multi_aff(
 	__isl_take isl_union_map *umap, __isl_take isl_multi_aff *ma);
 __isl_give isl_union_map *isl_union_map_preimage_domain_pw_multi_aff(
@@ -314,11 +311,9 @@ __isl_give isl_union_map *isl_union_set_unwrap(__isl_take isl_union_set *uset);
 
 __isl_export
 __isl_give isl_union_map *isl_union_map_zip(__isl_take isl_union_map *umap);
-__isl_export
 __isl_give isl_union_map *isl_union_map_curry(__isl_take isl_union_map *umap);
 __isl_give isl_union_map *isl_union_map_range_curry(
 	__isl_take isl_union_map *umap);
-__isl_export
 __isl_give isl_union_map *isl_union_map_uncurry(__isl_take isl_union_map *umap);
 
 __isl_give isl_union_map *isl_union_map_align_params(

--- a/include/isl/union_set.h
+++ b/include/isl/union_set.h
@@ -34,7 +34,6 @@ __isl_give isl_union_set *isl_union_set_reset_user(
 __isl_export
 __isl_give isl_union_set *isl_union_set_universe(
 	__isl_take isl_union_set *uset);
-__isl_export
 __isl_give isl_set *isl_union_set_params(__isl_take isl_union_set *uset);
 
 __isl_export
@@ -104,7 +103,6 @@ __isl_give isl_union_set *isl_union_set_project_out(
 __isl_give isl_union_set *isl_union_set_remove_divs(
 	__isl_take isl_union_set *bset);
 
-__isl_export
 isl_bool isl_union_set_is_params(__isl_keep isl_union_set *uset);
 __isl_export
 isl_bool isl_union_set_is_empty(__isl_keep isl_union_set *uset);
@@ -115,7 +113,6 @@ isl_bool isl_union_set_is_subset(__isl_keep isl_union_set *uset1,
 __isl_export
 isl_bool isl_union_set_is_equal(__isl_keep isl_union_set *uset1,
 	__isl_keep isl_union_set *uset2);
-__isl_export
 isl_bool isl_union_set_is_disjoint(__isl_keep isl_union_set *uset1,
 	__isl_keep isl_union_set *uset2);
 __isl_export


### PR DESCRIPTION
This reduces the difference with mainline.